### PR TITLE
Enable editing vehicle details

### DIFF
--- a/actualizar_vehiculo.php
+++ b/actualizar_vehiculo.php
@@ -2,23 +2,83 @@
 include 'conexion.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $vehiculo_id = $_POST['vehiculo_id'];
-    $observaciones = $_POST['observaciones'];
+    $vehiculo_id            = intval($_POST['vehiculo_id']);
+    $matricula              = trim($_POST['matricula'] ?? '');
+    $marca                  = trim($_POST['marca'] ?? '');
+    $modelo                 = trim($_POST['modelo'] ?? '');
+    $ano_fabricacion        = $_POST['ano_fabricacion'] ?? null;
+    $nivel_1                = $_POST['nivel_1'] ?? '';
+    $nivel_2                = $_POST['nivel_2'] ?? '';
+    $nivel_3                = $_POST['nivel_3'] ?? '';
+    $capacidad              = $_POST['capacidad'] ?? null;
+    $volumen                = $_POST['volumen'] ?? null;
+    $capacidad_arrastre     = $_POST['capacidad_arrastre'] ?? null;
+    $numero_ejes            = $_POST['numero_ejes'] ?? null;
+    $temperatura_controlada = isset($_POST['temperatura_controlada']) ? 1 : 0;
+    $forma_carga_lateral    = isset($_POST['forma_carga_lateral']) ? 1 : 0;
+    $forma_carga_detras     = isset($_POST['forma_carga_detras']) ? 1 : 0;
+    $forma_carga_arriba     = isset($_POST['forma_carga_arriba']) ? 1 : 0;
+    $adr                    = isset($_POST['adr']) ? 1 : 0;
+    $doble_conductor        = isset($_POST['doble_conductor']) ? 1 : 0;
+    $plataforma_elevadora   = isset($_POST['plataforma_elevadora']) ? 1 : 0;
+    $telefono               = trim($_POST['telefono'] ?? '');
+    $observaciones          = trim($_POST['observaciones'] ?? '');
+    $activo                 = isset($_POST['activo']) ? 1 : 0;
 
-    $sql = "UPDATE vehiculos SET observaciones = ? WHERE id = ?";
+    $sql = "UPDATE vehiculos SET
+                nivel_1 = ?,
+                nivel_2 = ?,
+                nivel_3 = ?,
+                matricula = ?,
+                marca = ?,
+                modelo = ?,
+                ano_fabricacion = ?,
+                capacidad = ?,
+                capacidad_arrastre = ?,
+                volumen = ?,
+                temperatura_controlada = ?,
+                forma_carga_lateral = ?,
+                forma_carga_detras = ?,
+                forma_carga_arriba = ?,
+                adr = ?,
+                doble_conductor = ?,
+                plataforma_elevadora = ?,
+                numero_ejes = ?,
+                telefono = ?,
+                observaciones = ?,
+                activo = ?
+            WHERE id = ?";
     $stmt = $conn->prepare($sql);
     if ($stmt) {
-        $stmt->bind_param("si", $observaciones, $vehiculo_id);
-        if ($stmt->execute()) {
-            echo "Observaciones actualizadas correctamente.";
-        } else {
-            echo "Error al actualizar las observaciones: " . $stmt->error;
-        }
-    } else {
-        echo "Error en la preparación de la consulta: " . $conn->error;
+        $stmt->bind_param(
+            "ssssssidddiiiiiiiissii",
+            $nivel_1,
+            $nivel_2,
+            $nivel_3,
+            $matricula,
+            $marca,
+            $modelo,
+            $ano_fabricacion,
+            $capacidad,
+            $capacidad_arrastre,
+            $volumen,
+            $temperatura_controlada,
+            $forma_carga_lateral,
+            $forma_carga_detras,
+            $forma_carga_arriba,
+            $adr,
+            $doble_conductor,
+            $plataforma_elevadora,
+            $numero_ejes,
+            $telefono,
+            $observaciones,
+            $activo,
+            $vehiculo_id
+        );
+        $stmt->execute();
+        $stmt->close();
     }
-    
-    // Redirigir de vuelta a los detalles del vehículo
+
     header('Location: ver_detalles_vehiculo.php?vehiculo_id=' . $vehiculo_id);
     exit();
 }

--- a/ver_detalles_vehiculo.php
+++ b/ver_detalles_vehiculo.php
@@ -129,6 +129,75 @@ $vehiculo = $res->fetch_assoc();
     </tbody>
 </table>
 
+<h2>Editar Vehículo</h2>
+<form method="POST" action="actualizar_vehiculo.php">
+    <input type="hidden" name="vehiculo_id" value="<?= $vehiculo_id ?>">
+    <label>Matrícula:</label>
+    <input type="text" name="matricula" value="<?= htmlspecialchars($vehiculo['matricula']) ?>" required><br>
+
+    <label>Marca:</label>
+    <input type="text" name="marca" value="<?= htmlspecialchars($vehiculo['marca']) ?>" required><br>
+
+    <label>Modelo:</label>
+    <input type="text" name="modelo" value="<?= htmlspecialchars($vehiculo['modelo']) ?>" required><br>
+
+    <label>Año de Fabricación:</label>
+    <input type="number" name="ano_fabricacion" value="<?= htmlspecialchars($vehiculo['ano_fabricacion']) ?>"><br>
+
+    <label>Tipo Principal:</label>
+    <input type="text" name="nivel_1" value="<?= htmlspecialchars($vehiculo['nivel_1']) ?>" required><br>
+
+    <label>Subcategoría:</label>
+    <input type="text" name="nivel_2" value="<?= htmlspecialchars($vehiculo['nivel_2']) ?>" required><br>
+
+    <label>Especificación:</label>
+    <input type="text" name="nivel_3" value="<?= htmlspecialchars($vehiculo['nivel_3']) ?>"><br>
+
+    <label>Capacidad (Ton):</label>
+    <input type="number" step="0.1" name="capacidad" value="<?= htmlspecialchars($vehiculo['capacidad']) ?>"><br>
+
+    <label>Volumen (m³):</label>
+    <input type="number" step="0.1" name="volumen" value="<?= htmlspecialchars($vehiculo['volumen']) ?>"><br>
+
+    <label>Cap. Arrastre (Ton):</label>
+    <input type="number" step="0.1" name="capacidad_arrastre" value="<?= htmlspecialchars($vehiculo['capacidad_arrastre']) ?>"><br>
+
+    <label>Número de Ejes:</label>
+    <input type="number" name="numero_ejes" value="<?= htmlspecialchars($vehiculo['numero_ejes']) ?>"><br>
+
+    <label>Temperatura Controlada:</label>
+    <input type="checkbox" name="temperatura_controlada" value="1" <?= $vehiculo['temperatura_controlada'] ? 'checked' : '' ?>><br>
+
+    <label>Forma de Carga - Lateral:</label>
+    <input type="checkbox" name="forma_carga_lateral" value="1" <?= $vehiculo['forma_carga_lateral'] ? 'checked' : '' ?>><br>
+
+    <label>Forma de Carga - Detrás:</label>
+    <input type="checkbox" name="forma_carga_detras" value="1" <?= $vehiculo['forma_carga_detras'] ? 'checked' : '' ?>><br>
+
+    <label>Forma de Carga - Arriba:</label>
+    <input type="checkbox" name="forma_carga_arriba" value="1" <?= $vehiculo['forma_carga_arriba'] ? 'checked' : '' ?>><br>
+
+    <label>ADR:</label>
+    <input type="checkbox" name="adr" value="1" <?= $vehiculo['adr'] ? 'checked' : '' ?>><br>
+
+    <label>Doble Conductor:</label>
+    <input type="checkbox" name="doble_conductor" value="1" <?= $vehiculo['doble_conductor'] ? 'checked' : '' ?>><br>
+
+    <label>Plataforma Elevadora:</label>
+    <input type="checkbox" name="plataforma_elevadora" value="1" <?= $vehiculo['plataforma_elevadora'] ? 'checked' : '' ?>><br>
+
+    <label>Teléfono:</label>
+    <input type="text" name="telefono" value="<?= htmlspecialchars($vehiculo['telefono']) ?>"><br>
+
+    <label>Observaciones:</label>
+    <textarea name="observaciones" rows="4" cols="50"><?= htmlspecialchars($vehiculo['observaciones']) ?></textarea><br>
+
+    <label>Activo:</label>
+    <input type="checkbox" name="activo" value="1" <?= $vehiculo['activo'] ? 'checked' : '' ?>><br><br>
+
+    <button type="submit">Guardar Cambios</button>
+</form>
+
 
 <?php
 $sqlDocs = "SELECT id, nombre_archivo, ruta_archivo, fecha_subida FROM documentos_vehiculos WHERE vehiculo_id = ? ORDER BY fecha_subida DESC";


### PR DESCRIPTION
## Summary
- allow editing vehicle data directly from the details view
- extend vehicle update logic to handle all relevant fields

## Testing
- `php -l ver_detalles_vehiculo.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866a70701408329a51cc68572384e12