### PR TITLE
Add collapsible edit form

### DIFF
--- a/ver_detalles_vehiculo.php
+++ b/ver_detalles_vehiculo.php
@@ -88,6 +88,11 @@ $vehiculo = $res->fetch_assoc();
     <meta charset="UTF-8">
     <title>Detalles del Vehículo</title>
     <link rel="stylesheet" href="styles.css">
+    <style>
+        .hidden {
+            display: none;
+        }
+    </style>
 </head>
 <body>
 <?php include 'header.php'; ?>
@@ -129,6 +134,8 @@ $vehiculo = $res->fetch_assoc();
     </tbody>
 </table>
 
+<button id="toggleEditBtn">Editar camión</button>
+<div id="editVehicleForm" class="hidden" style="margin-top:20px;">
 <h2>Editar Vehículo</h2>
 <form method="POST" action="actualizar_vehiculo.php">
     <input type="hidden" name="vehiculo_id" value="<?= $vehiculo_id ?>">
@@ -197,6 +204,7 @@ $vehiculo = $res->fetch_assoc();
 
     <button type="submit">Guardar Cambios</button>
 </form>
+</div>
 
 
 <?php
@@ -242,6 +250,18 @@ $documentos = $res_docs->fetch_all(MYSQLI_ASSOC);
 <button onclick="history.back()">Volver</button>
 
 <?php include 'footer.php'; ?>
+
+<script>
+    const toggleBtn = document.getElementById('toggleEditBtn');
+    const editForm = document.getElementById('editVehicleForm');
+    toggleBtn.addEventListener('click', () => {
+        if (editForm.classList.contains('hidden')) {
+            editForm.classList.remove('hidden');
+        } else {
+            editForm.classList.add('hidden');
+        }
+    });
+</script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- hide the vehicle edit form by default and show it when clicking **Editar camión**

## Testing
- `php -l ver_detalles_vehiculo.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866af4296508329a159b597f4c2346b