### PR TITLE
Ensure dropdown buttons stay black

### DIFF
--- a/header.php
+++ b/header.php
@@ -187,7 +187,7 @@ if (!empty($_SESSION['impersonador_id'])) {
                                padding: 16px 24px;
                                background: none;
                                border: none;
-                               color: black;
+                               color: black !important;
                                font-size: 1em;
                                text-align: left;">
                     Gestión Interna ▾
@@ -236,7 +236,7 @@ if (!empty($_SESSION['impersonador_id'])) {
                                padding: 16px 24px;
                                background: none;
                                border: none;
-                               color: black;
+                               color: black !important;
                                font-size: 1em;
                                text-align: left;">
                     Gestión Económica ▾


### PR DESCRIPTION
## Summary
- update Gestion Interna and Gestion Económica dropdown button styles to force black text

## Testing
- `php -l header.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d57b4fd748329b22e38e8d423a300