### PR TITLE
Remove 'consultar consumo mensual' link from profile

### DIFF
--- a/header.php
+++ b/header.php
@@ -242,15 +242,6 @@ if (!empty($_SESSION['impersonador_id'])) {
                     Gestión Económica ▾
                 </button>
                 <div id="gestionEconomicaDropdown" style="display:none;">
-                    <a href="/Perfil/portes_consumo_mensual.php"
-                       style="display: block;
-                              padding: 16px 24px;
-                              padding-left: 40px;
-                              color: black;
-                              font-size: 1em;
-                              text-decoration: none;">
-                        Consultar consumo mensual
-                    </a>
                     <a href="/facturas_intertrucker.php"
                        style="display: block;
                               padding: 16px 24px;


### PR DESCRIPTION
## Summary
- remove the monthly consumption option from the navigation dropdown so it's not shown on profile pages

## Testing
- `php -l header.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d5c12c68c83298f8c735c6bcbc8b8