### PR TITLE
Add icons to management dropdown

### DIFF
--- a/header.php
+++ b/header.php
@@ -190,6 +190,11 @@ if (!empty($_SESSION['impersonador_id'])) {
                                color: black !important;
                                font-size: 1em;
                                text-align: left;">
+                    <img src="/imagenes/iconos/gestion_interna.svg" alt="Gestión interna"
+                         style="width: 24px;
+                                height: 24px;
+                                vertical-align: middle;
+                                margin-right: 12px;">
                     Gestión Interna ▾
                 </button>
                 <div id="gestionInternaDropdown" style="display:none;">
@@ -248,6 +253,11 @@ if (!empty($_SESSION['impersonador_id'])) {
                                color: black !important;
                                font-size: 1em;
                                text-align: left;">
+                    <img src="/imagenes/iconos/gestion_economica.svg" alt="Gestión económica"
+                         style="width: 24px;
+                                height: 24px;
+                                vertical-align: middle;
+                                margin-right: 12px;">
                     Gestión Económica ▾
                 </button>
                 <div id="gestionEconomicaDropdown" style="display:none;">

--- a/imagenes/iconos/gestion_economica.svg
+++ b/imagenes/iconos/gestion_economica.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="#001C80">
+  <!-- Moneda superior -->
+  <circle cx="12" cy="7" r="4" fill="#e9ecef" stroke="#001C80" stroke-width="2" />
+  <!-- Moneda inferior -->
+  <ellipse cx="12" cy="16" rx="7" ry="4" fill="#e9ecef" stroke="#001C80" stroke-width="2" />
+  <ellipse cx="12" cy="12" rx="7" ry="4" fill="#e9ecef" stroke="#001C80" stroke-width="2" />
+</svg>


### PR DESCRIPTION
## Summary
- show `gestion_interna.svg` and `gestion_economica.svg` for management dropdowns
- add missing `gestion_economica.svg` icon

## Testing
- `php -l header.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e3b805100832980c10df935f93bfd