### PR TITLE
Conditionally show Gestores link for admins

### DIFF
--- a/header.php
+++ b/header.php
@@ -225,6 +225,7 @@ if (!empty($_SESSION['impersonador_id'])) {
                               text-decoration: none;">
                         Vehículos
                     </a>
+<?php if (!empty($_SESSION['rol']) && $_SESSION['rol'] === 'administrador'): ?>
                     <a href="/gestionar_colaboradores.php"
                        style="display: block;
                               padding: 16px 24px;
@@ -234,6 +235,7 @@ if (!empty($_SESSION['impersonador_id'])) {
                               text-decoration: none;">
                         Gestores
                     </a>
+<?php endif; ?>
                     <a href="/Perfil/gestionar_direcciones_empresa.php"
                        style="display: block;
                               padding: 16px 24px;


### PR DESCRIPTION
## Summary
- hide the Gestores link unless the user role is `administrador`

## Testing
- `php -r 'session_start(); $_SESSION["rol"]="administrador"; $_SESSION["nombre_usuario"]="Admin"; include "header.php";' | grep -o "Gestores" | wc -l`
- `php -r 'session_start(); $_SESSION["rol"]="usuario"; $_SESSION["nombre_usuario"]="Usuario"; include "header.php";' | grep -o "Gestores" | wc -l`
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_68742ce0aaf88329aef80f2c3ec08f18