### PR TITLE
Fix trucker status link error and refresh listing

### DIFF
--- a/editar_camionero.php
+++ b/editar_camionero.php
@@ -375,7 +375,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <?php endif; ?>
 
 <p>
-  <button type="button" onclick="history.back()">Volver atrás</button>
+  <button type="button" onclick="window.location.href='my_truckers.php'">Volver atrás</button>
 </p>
 
 </body>

--- a/my_truckers.php
+++ b/my_truckers.php
@@ -190,10 +190,9 @@ if (isset($_GET['toggle_id']) && isset($_GET['estado'])) {
                     <td><?= htmlspecialchars($camionero['fecha_nacimiento']) ?></td>
                     <td><?= htmlspecialchars($camionero['fecha_contratacion']) ?></td>
                     <td>
-                        <a href="my_truckers.php?toggle_id=<?= $camionero['camionero_id'] ?>&estado=<?= $camionero['activo'] ?>"
-                           class="toggle-button <?= $camionero['activo'] ? 'activo' : 'no-activo' ?>">
+                        <span class="toggle-button <?= $camionero['activo'] ? 'activo' : 'no-activo' ?>">
                             <?= $camionero['activo'] ? 'Activo' : 'No Activo' ?>
-                        </a>
+                        </span>
                     </td>
                     <td>
                         <a href="editar_camionero.php?id=<?= $camionero['camionero_id'] ?>">Detalles</a>


### PR DESCRIPTION
## Summary
- remove hyperlink on driver status to avoid toggle errors
- redirect back from edit driver page to listing to force refresh

## Testing
- `php -l my_truckers.php`
- `php -l editar_camionero.php`


------
https://chatgpt.com/codex/tasks/task_e_687624675ca483298692b5a318299228