### PR TITLE
Load DB config from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DB_HOST=localhost
+DB_USER=root
+DB_PASS=secret
+DB_NAME=mydatabase

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# InterTrucker Web
+
+This project requires database connection credentials provided via environment variables.
+
+Set the following variables in your environment or in a `.env` file before running any PHP scripts:
+
+```
+DB_HOST=your-database-host
+DB_USER=your-database-user
+DB_PASS=your-database-password
+DB_NAME=your-database-name
+```
+
+An example file is provided as `.env.example`.

--- a/api/autologin.php
+++ b/api/autologin.php
@@ -20,11 +20,11 @@ if ($usuarioId < 1) {
     exit;
 }
 
-// --- 2) Conectar a la base de datos (ajusta credenciales) ---
-$dbHost = "db5016197746.hosting-data.io";
-$dbUser = "dbu4085097";
-$dbPass = "123intertruckerya";
-$dbName = "dbs13181300";
+// --- 2) Conectar a la base de datos usando variables de entorno ---
+$dbHost = getenv('DB_HOST');
+$dbUser = getenv('DB_USER');
+$dbPass = getenv('DB_PASS');
+$dbName = getenv('DB_NAME');
 
 try {
     $pdo = new PDO(

--- a/api/autologin_mecanismo.php
+++ b/api/autologin_mecanismo.php
@@ -17,11 +17,11 @@ if (empty($token)) {
     exit;
 }
 
-// 2) Conectar a la base de datos (ajusta credenciales a tu hosting)
-$dbHost = "db5016197746.hosting-data.io";
-$dbUser = "dbu4085097";
-$dbPass = "123intertruckerya";
-$dbName = "dbs13181300";
+// 2) Conectar a la base de datos usando variables de entorno
+$dbHost = getenv('DB_HOST');
+$dbUser = getenv('DB_USER');
+$dbPass = getenv('DB_PASS');
+$dbName = getenv('DB_NAME');
 
 try {
     $pdo = new PDO(

--- a/api/detalles_portes.php
+++ b/api/detalles_portes.php
@@ -8,10 +8,10 @@ header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 
-$servername = "db5016197746.hosting-data.io";
-$username   = "dbu4085097";
-$password   = "123intertruckerya";
-$dbname     = "dbs13181300";
+$servername = getenv('DB_HOST');
+$username   = getenv('DB_USER');
+$password   = getenv('DB_PASS');
+$dbname     = getenv('DB_NAME');
 
 $conn = new mysqli($servername, $username, $password, $dbname);
 

--- a/api/eventos_firma.php
+++ b/api/eventos_firma.php
@@ -9,11 +9,11 @@ header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Methods: POST");
 header("Access-Control-Allow-Headers: Content-Type, Authorization");
 
-// DATOS DE CONEXIÓN
-$servername = "db5016197746.hosting-data.io";
-$username   = "dbu4085097";
-$password   = "123intertruckerya";
-$dbname     = "dbs13181300";
+// DATOS DE CONEXIÓN obtenidos de variables de entorno
+$servername = getenv('DB_HOST');
+$username   = getenv('DB_USER');
+$password   = getenv('DB_PASS');
+$dbname     = getenv('DB_NAME');
 
 // Conexión a la base de datos
 $conn = new mysqli($servername, $username, $password, $dbname);

--- a/api/eventos_porte.php
+++ b/api/eventos_porte.php
@@ -10,11 +10,11 @@ header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 
-// Credenciales de la base de datos
-$servername = "db5016197746.hosting-data.io";
-$username = "dbu4085097";
-$password = "123intertruckerya";
-$dbname = "dbs13181300";
+// Credenciales de la base de datos obtenidas de variables de entorno
+$servername = getenv('DB_HOST');
+$username   = getenv('DB_USER');
+$password   = getenv('DB_PASS');
+$dbname     = getenv('DB_NAME');
 
 // Conectar a la base de datos
 $conn = new mysqli($servername, $username, $password, $dbname);

--- a/api/eventos_salida.php
+++ b/api/eventos_salida.php
@@ -10,10 +10,10 @@ header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Methods: POST");
 header("Access-Control-Allow-Headers: Content-Type, Authorization");
 
-$servername = "db5016197746.hosting-data.io";
-$username   = "dbu4085097";
-$password   = "123intertruckerya";
-$dbname     = "dbs13181300";
+$servername = getenv('DB_HOST');
+$username   = getenv('DB_USER');
+$password   = getenv('DB_PASS');
+$dbname     = getenv('DB_NAME');
 
 $conn = new mysqli($servername, $username, $password, $dbname);
 if ($conn->connect_error) {

--- a/api/facturas_usuario.php
+++ b/api/facturas_usuario.php
@@ -10,11 +10,11 @@ ini_set('display_errors', 0);
 ini_set('display_startup_errors', 0);
 error_reporting(0);
 
-// Conexión a la base de datos
-$servername = "db5016197746.hosting-data.io";
-$username   = "dbu4085097";
-$password   = "123intertruckerya";
-$dbname     = "dbs13181300";
+// Conexión a la base de datos usando variables de entorno
+$servername = getenv('DB_HOST');
+$username   = getenv('DB_USER');
+$password   = getenv('DB_PASS');
+$dbname     = getenv('DB_NAME');
 
 $conn = new mysqli($servername, $username, $password, $dbname);
 if ($conn->connect_error) {

--- a/api/guardar_estado_mercancia.php
+++ b/api/guardar_estado_mercancia.php
@@ -10,11 +10,11 @@ header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Methods: POST");
 header("Access-Control-Allow-Headers: Content-Type, Authorization");
 
-// Credenciales de la base de datos
-$servername = "db5016197746.hosting-data.io";
-$username = "dbu4085097";
-$password = "123intertruckerya";
-$dbname = "dbs13181300";
+// Credenciales de la base de datos obtenidas de variables de entorno
+$servername = getenv('DB_HOST');
+$username   = getenv('DB_USER');
+$password   = getenv('DB_PASS');
+$dbname     = getenv('DB_NAME');
 
 // Conectar a la base de datos
 $conn = new mysqli($servername, $username, $password, $dbname);

--- a/api/multimedia_portes.php
+++ b/api/multimedia_portes.php
@@ -10,11 +10,11 @@ header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 
-// Credenciales de la base de datos
-$servername = "db5016197746.hosting-data.io";
-$username = "dbu4085097";
-$password = "123intertruckerya";
-$dbname = "dbs13181300";
+// Credenciales de la base de datos obtenidas de variables de entorno
+$servername = getenv('DB_HOST');
+$username   = getenv('DB_USER');
+$password   = getenv('DB_PASS');
+$dbname     = getenv('DB_NAME');
 
 // Conectar a la base de datos
 $conn = new mysqli($servername, $username, $password, $dbname);

--- a/api/obtener-datos-usuario.php
+++ b/api/obtener-datos-usuario.php
@@ -10,11 +10,11 @@ header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 
-// Credenciales de la base de datos
-$servername = "db5016197746.hosting-data.io";
-$username = "dbu4085097";
-$password = "123intertruckerya";
-$dbname = "dbs13181300";
+// Credenciales de la base de datos obtenidas de variables de entorno
+$servername = getenv('DB_HOST');
+$username   = getenv('DB_USER');
+$password   = getenv('DB_PASS');
+$dbname     = getenv('DB_NAME');
 
 // Conectar a la base de datos
 $conn = new mysqli($servername, $username, $password, $dbname);

--- a/api/portes_tren.php
+++ b/api/portes_tren.php
@@ -10,11 +10,11 @@ header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 
-// Credenciales de la base de datos
-$servername = "db5016197746.hosting-data.io";
-$username = "dbu4085097";
-$password = "123intertruckerya";
-$dbname = "dbs13181300";
+// Credenciales de la base de datos obtenidas de variables de entorno
+$servername = getenv('DB_HOST');
+$username   = getenv('DB_USER');
+$password   = getenv('DB_PASS');
+$dbname     = getenv('DB_NAME');
 
 // Conectar a la base de datos
 $conn = new mysqli($servername, $username, $password, $dbname);

--- a/api/subir_factura.php
+++ b/api/subir_factura.php
@@ -24,10 +24,10 @@ header('Access-Control-Allow-Headers: Content-Type, Authorization');
 /* --------------------------------------------------------------
  * 0) Conexión a la base de datos
  * ------------------------------------------------------------*/
-$servername = 'db5016197746.hosting-data.io';
-$username   = 'dbu4085097';
-$password   = '123intertruckerya';
-$dbname     = 'dbs13181300';
+$servername = getenv('DB_HOST');
+$username   = getenv('DB_USER');
+$password   = getenv('DB_PASS');
+$dbname     = getenv('DB_NAME');
 
 $conn = new mysqli($servername, $username, $password, $dbname);
 if ($conn->connect_error) {

--- a/api/tren.php
+++ b/api/tren.php
@@ -8,10 +8,10 @@ header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 
-$servername = "db5016197746.hosting-data.io";
-$username   = "dbu4085097";
-$password   = "123intertruckerya";
-$dbname     = "dbs13181300";
+$servername = getenv('DB_HOST');
+$username   = getenv('DB_USER');
+$password   = getenv('DB_PASS');
+$dbname     = getenv('DB_NAME');
 
 $conn = new mysqli($servername, $username, $password, $dbname);
 

--- a/api/tren_y_portes_camionero.php
+++ b/api/tren_y_portes_camionero.php
@@ -10,11 +10,11 @@ header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 
-// Credenciales de la base de datos
-$servername = "db5016197746.hosting-data.io";
-$username   = "dbu4085097";
-$password   = "123intertruckerya";
-$dbname     = "dbs13181300";
+// Credenciales de la base de datos obtenidas de variables de entorno
+$servername = getenv('DB_HOST');
+$username   = getenv('DB_USER');
+$password   = getenv('DB_PASS');
+$dbname     = getenv('DB_NAME');
 
 // Conectar al servidor
 $conn = new mysqli($servername, $username, $password, $dbname);

--- a/api/verificar-credenciales.php
+++ b/api/verificar-credenciales.php
@@ -33,11 +33,11 @@ if (empty($email) || empty($contrasena)) {
     exit;
 }
 
-// 3) Datos de conexión a tu BD (ajusta según corresponda)
-$servername = "db5016197746.hosting-data.io";
-$username   = "dbu4085097";
-$password   = "123intertruckerya";
-$dbname     = "dbs13181300";
+// 3) Datos de conexión obtenidos de variables de entorno
+$servername = getenv('DB_HOST');
+$username   = getenv('DB_USER');
+$password   = getenv('DB_PASS');
+$dbname     = getenv('DB_NAME');
 
 // 4) Conexión PDO
 try {

--- a/conexion.php
+++ b/conexion.php
@@ -9,11 +9,11 @@ if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
 
-// Configuración de la base de datos
-$servername = "db5016197746.hosting-data.io"; 
-$username = "dbu4085097"; 
-$password = "123intertruckerya"; 
-$dbname = "dbs13181300";
+// Configuración de la base de datos desde variables de entorno
+$servername = getenv('DB_HOST');
+$username   = getenv('DB_USER');
+$password   = getenv('DB_PASS');
+$dbname     = getenv('DB_NAME');
 
 // Crear la conexión
 $conn = new mysqli($servername, $username, $password, $dbname);

--- a/eventos_porte.php
+++ b/eventos_porte.php
@@ -10,11 +10,11 @@ header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 
-// Credenciales de la base de datos
-$servername = "db5016197746.hosting-data.io";
-$username = "dbu4085097";
-$password = "123intertruckerya";
-$dbname = "dbs13181300";
+// Credenciales de la base de datos obtenidas de variables de entorno
+$servername = getenv('DB_HOST');
+$username   = getenv('DB_USER');
+$password   = getenv('DB_PASS');
+$dbname     = getenv('DB_NAME');
 
 // Conectar a la base de datos
 $conn = new mysqli($servername, $username, $password, $dbname);

--- a/importar_portes.php
+++ b/importar_portes.php
@@ -61,10 +61,10 @@ if (isset($_POST['importar']) && isset($_FILES['fichero_datos'])) {
     // ------------------------------------------------
     // 2.4. Conexión PDO + transacción
     // ------------------------------------------------
-    $dbHost = "db5016197746.hosting-data.io";
-    $dbUser = "dbu4085097";
-    $dbPass = "123intertruckerya";
-    $dbName = "dbs13181300";
+    $dbHost = getenv('DB_HOST');
+    $dbUser = getenv('DB_USER');
+    $dbPass = getenv('DB_PASS');
+    $dbName = getenv('DB_NAME');
     $dsn = "mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4";
 
     try {
@@ -292,7 +292,7 @@ function parseRow(array $header, array $row): array {
                 break;
 
             case 'adr':
-                $data['adr'] = boolVal($val);
+                $data['adr'] = boolTextToInt($val);
                 break;
 
             default:
@@ -352,7 +352,7 @@ function parseXmlNode(SimpleXMLElement $nodo): array {
                 processFechaHoraLoc($data, $val, 'entrega');
                 break;
             case 'adr':
-                $data['adr'] = boolVal($val);
+                $data['adr'] = boolTextToInt($val);
                 break;
             default:
                 if ($val !== '') {
@@ -494,10 +494,10 @@ function fixHora(string $val): string {
 }
 
 /**
- * boolVal()
+ * boolTextToInt()
  * Convierte “sí”, “yes”, “true”, etc. a 1 y “no”, “false” a 0
  */
-function boolVal(string $s): int {
+function boolTextToInt(string $s): int {
     $s = mb_strtolower(trim($s));
     $yes = ["si","sí","yes","oui","ja","sim","true","1"];
     $no  = ["no","false","nein","non","nao","não","0"];

--- a/login_directo.php
+++ b/login_directo.php
@@ -13,9 +13,9 @@ if ($user_id <= 0 || empty($token_sesion)) {
 // 3) Conexión a la BD (ajusta tus credenciales si cambian)
 try {
     $pdo = new PDO(
-        "mysql:host=db5016197746.hosting-data.io;dbname=dbs13181300;charset=utf8mb4",
-        "dbu4085097",
-        "123intertruckerya"
+        "mysql:host=".getenv('DB_HOST').";dbname=".getenv('DB_NAME').";charset=utf8mb4",
+        getenv('DB_USER'),
+        getenv('DB_PASS')
     );
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 } catch (Exception $e) {


### PR DESCRIPTION
## Summary
- read DB credentials from environment variables
- remove hard-coded DB credentials from scripts
- document required variables in README and sample .env file

## Testing
- `php -l api/autologin.php`
- `php -l api/autologin_mecanismo.php`
- `php -l api/detalles_portes.php`
- `php -l api/eventos_firma.php`
- `php -l api/eventos_porte.php`
- `php -l api/eventos_salida.php`
- `php -l api/facturas_usuario.php`
- `php -l api/guardar_estado_mercancia.php`
- `php -l api/multimedia_portes.php`
- `php -l api/obtener-datos-usuario.php`
- `php -l api/portes_tren.php`
- `php -l api/subir_factura.php`
- `php -l api/tren.php`
- `php -l api/tren_y_portes_camionero.php`
- `php -l api/verificar-credenciales.php`
- `php -l conexion.php`
- `php -l eventos_porte.php`
- `php -l importar_portes.php`
- `php -l login_directo.php`


------
https://chatgpt.com/codex/tasks/task_e_687695968be48329b6c7aae8659329fd