### PR TITLE
Add document upload for new porte

### DIFF
--- a/Perfil/crear_porte.php
+++ b/Perfil/crear_porte.php
@@ -119,7 +119,7 @@ $conn->close();
     
     <main>
         <h1>Crear Nuevo Porte</h1>
-        <form action="guardar_porte.php" method="POST">
+        <form action="guardar_porte.php" method="POST" enctype="multipart/form-data">
             <fieldset>
                 <legend><strong>La Mercancía:</strong></legend>
                 <label for="descripcion_mercancia">Naturaleza y Embalaje:</label>
@@ -309,6 +309,11 @@ $conn->close();
                 
                 <label for="no_se_puede_remontar">No Se Puede Remontar:</label>
                 <input type="checkbox" id="no_se_puede_remontar" name="no_se_puede_remontar"><br>
+            </fieldset>
+
+            <fieldset>
+                <legend>Documentos adjuntos</legend>
+                <input type="file" name="documentos_porte[]" multiple accept=".pdf,.jpg,.jpeg,.png">
             </fieldset>
 
             <!-- Campos ocultos para almacenar ID y tipo de cada entidad/usuario -->

--- a/bd/dbs13181300.sql
+++ b/bd/dbs13181300.sql
@@ -176,6 +176,21 @@ CREATE TABLE `documentos_vehiculos` (
 -- --------------------------------------------------------
 
 --
+-- Estructura de tabla para la tabla `documentos_portes`
+--
+
+CREATE TABLE `documentos_portes` (
+  `id` int(11) NOT NULL,
+  `porte_id` int(11) NOT NULL,
+  `nombre_archivo` varchar(255) NOT NULL,
+  `ruta_archivo` varchar(255) NOT NULL,
+  `tipo_documento` varchar(50) NOT NULL,
+  `fecha_subida` datetime DEFAULT current_timestamp()
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
+
+-- --------------------------------------------------------
+
+--
 -- Estructura de tabla para la tabla `entidades`
 --
 
@@ -1038,6 +1053,13 @@ ALTER TABLE `documentos_vehiculos`
   ADD KEY `vehiculo_id` (`vehiculo_id`);
 
 --
+-- Indices de la tabla `documentos_portes`
+--
+ALTER TABLE `documentos_portes`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `porte_id` (`porte_id`);
+
+--
 -- Indices de la tabla `entidades`
 --
 ALTER TABLE `entidades`
@@ -1291,6 +1313,12 @@ ALTER TABLE `documentos_vehiculos`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 
 --
+-- AUTO_INCREMENT de la tabla `documentos_portes`
+--
+ALTER TABLE `documentos_portes`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
 -- AUTO_INCREMENT de la tabla `entidades`
 --
 ALTER TABLE `entidades`
@@ -1500,6 +1528,12 @@ ALTER TABLE `documentos_usuarios`
 --
 ALTER TABLE `documentos_vehiculos`
   ADD CONSTRAINT `documentos_vehiculos_ibfk_1` FOREIGN KEY (`vehiculo_id`) REFERENCES `vehiculos` (`id`) ON DELETE CASCADE;
+
+--
+-- Filtros para la tabla `documentos_portes`
+--
+ALTER TABLE `documentos_portes`
+  ADD CONSTRAINT `documentos_portes_ibfk_1` FOREIGN KEY (`porte_id`) REFERENCES `portes` (`id`) ON DELETE CASCADE;
 
 --
 -- Filtros para la tabla `eventos`

--- a/crear_porte.php
+++ b/crear_porte.php
@@ -119,7 +119,7 @@ $conn->close();
     
     <main>
         <h1>Crear Nuevo Porte</h1>
-        <form action="guardar_porte.php" method="POST">
+        <form action="guardar_porte.php" method="POST" enctype="multipart/form-data">
             <fieldset>
                 <legend>La Mercancía</legend>
                 <label for="descripcion_mercancia">Naturaleza y Embalaje:</label>
@@ -309,6 +309,11 @@ $conn->close();
                 
                 <label for="no_se_puede_remontar">No Se Puede Remontar:</label>
                 <input type="checkbox" id="no_se_puede_remontar" name="no_se_puede_remontar"><br>
+            </fieldset>
+
+            <fieldset>
+                <legend>Documentos adjuntos</legend>
+                <input type="file" name="documentos_porte[]" multiple accept=".pdf,.jpg,.jpeg,.png">
             </fieldset>
 
             <!-- Campos ocultos para almacenar ID y tipo de cada entidad/usuario -->


### PR DESCRIPTION
## Summary
- allow uploading attachments in `crear_porte.php` and `Perfil/crear_porte.php`
- store uploaded docs in `guardar_porte.php`
- create `uploads/portes` directory
- add `documentos_portes` table to SQL schema

## Testing
- `php -l crear_porte.php`
- `php -l Perfil/crear_porte.php`
- `php -l guardar_porte.php`


------
https://chatgpt.com/codex/tasks/task_e_687795a6911c832991891651d897eba9