### PR TITLE
Secure document downloads

### DIFF
--- a/descargar_documento.php
+++ b/descargar_documento.php
@@ -1,0 +1,73 @@
+<?php
+session_start();
+require_once __DIR__ . '/conexion.php';
+
+if (!isset($_SESSION['usuario_id'])) {
+    die('Debe iniciar sesión.');
+}
+
+if (!isset($_GET['id'], $_GET['tipo']) || !is_numeric($_GET['id'])) {
+    die('Parámetros inválidos.');
+}
+
+$id = intval($_GET['id']);
+$tipo = $_GET['tipo'];
+
+switch ($tipo) {
+    case 'usuario':
+        $sql = "SELECT ruta_archivo, usuario_id AS owner
+                FROM documentos_usuarios
+                WHERE id = ?";
+        break;
+    case 'camionero':
+        $sql = "SELECT d.ruta_archivo, c.usuario_id AS owner
+                FROM documentos_camioneros d
+                JOIN camioneros c ON d.camionero_id = c.id
+                WHERE d.id = ?";
+        break;
+    case 'vehiculo':
+        $sql = "SELECT d.ruta_archivo, v.usuario_id AS owner
+                FROM documentos_vehiculos d
+                JOIN vehiculos v ON d.vehiculo_id = v.id
+                WHERE d.id = ?";
+        break;
+    case 'porte':
+        $sql = "SELECT d.ruta_archivo, p.usuario_creador_id AS owner
+                FROM documentos_portes d
+                JOIN portes p ON d.porte_id = p.id
+                WHERE d.id = ?";
+        break;
+    default:
+        die('Tipo de documento no válido.');
+}
+
+$stmt = $conn->prepare($sql);
+$stmt->bind_param('i', $id);
+$stmt->execute();
+$result = $stmt->get_result()->fetch_assoc();
+
+if (!$result) {
+    die('Documento no encontrado.');
+}
+
+$ownerId = (int)$result['owner'];
+$usuarioId = (int)$_SESSION['usuario_id'];
+$esAdmin = isset($_SESSION['rol']) && $_SESSION['rol'] === 'administrador';
+
+if ($usuarioId !== $ownerId && !$esAdmin) {
+    die('No tiene permiso para acceder a este documento.');
+}
+
+$ruta = __DIR__ . '/' . $result['ruta_archivo'];
+if (!is_file($ruta)) {
+    die('Archivo no encontrado.');
+}
+
+$nombre = basename($ruta);
+$mime = mime_content_type($ruta);
+header('Content-Type: ' . $mime);
+header('Content-Disposition: attachment; filename="' . $nombre . '"');
+header('Content-Length: ' . filesize($ruta));
+readfile($ruta);
+exit;
+?>

--- a/detalles_colaborador.php
+++ b/detalles_colaborador.php
@@ -159,7 +159,7 @@ function toggleCamioneroFields(){
 <tr>
   <td><?=$d['id']?></td>
   <td><?=$d['tipo_documento']?></td>
-  <td><a href="/<?=$d['ruta_archivo']?>" target="_blank"><?=htmlspecialchars($d['nombre_archivo'])?></a></td>
+  <td><a href="descargar_documento.php?id=<?=$d['id']?>&tipo=usuario" target="_blank"><?=htmlspecialchars($d['nombre_archivo'])?></a></td>
   <td><?=$d['fecha_subida']?></td>
   <td>
      <form method="POST" style="display:inline">

--- a/editar_camionero.php
+++ b/editar_camionero.php
@@ -381,7 +381,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
           <td><?= htmlspecialchars($doc['nombre_archivo']) ?></td>
           <td><?= htmlspecialchars($doc['fecha_subida']) ?></td>
           <td>
-            <a href="<?= htmlspecialchars($doc['ruta_archivo']) ?>" target="_blank">Ver</a>
+            <a href="descargar_documento.php?id=<?= $doc['id'] ?>&tipo=camionero" target="_blank">Ver</a>
             <!-- Aquí podrías añadir un botón para eliminar el documento si quieres -->
           </td>
         </tr>

--- a/uploads/.htaccess
+++ b/uploads/.htaccess
@@ -1,0 +1,1 @@
+Deny from all

--- a/ver_detalles_vehiculo.php
+++ b/ver_detalles_vehiculo.php
@@ -219,7 +219,7 @@ $documentos = $res_docs->fetch_all(MYSQLI_ASSOC);
         <tr>
             <td><?= htmlspecialchars($doc['nombre_archivo']) ?></td>
             <td><?= htmlspecialchars($doc['fecha_subida']) ?></td>
-            <td><a href="<?= htmlspecialchars($doc['ruta_archivo']) ?>" target="_blank">Ver / Descargar</a></td>
+            <td><a href="descargar_documento.php?id=<?= $doc['id'] ?>&tipo=vehiculo" target="_blank">Ver / Descargar</a></td>
         </tr>
     <?php endforeach; ?>
     </tbody>


### PR DESCRIPTION
## Summary
- restrict public access to files under `uploads`
- add `descargar_documento.php` to validate permissions before serving uploads
- update document links to use the new secure download handler

## Testing
- `php` was not available so no tests were run


------
https://chatgpt.com/codex/tasks/task_e_6877fdfc6ad08329b7ed30319cd03269