### PR TITLE
Add centralized auth helpers

### DIFF
--- a/Perfil/listado_destinatario.php
+++ b/Perfil/listado_destinatario.php
@@ -1,11 +1,7 @@
-<?php
-session_start();
-include 'conexion.php';
-
-if (!isset($_SESSION['usuario_id'])) {
-    header("Location: login.php");
-    exit();
-}
+$baseDir = dirname(__DIR__);
+require_once $baseDir.'/auth.php';
+require_login();
+include $baseDir.'/conexion.php';
 $usuario_id = (int)$_SESSION['usuario_id'];
 
 // Recoger filtros de la URL

--- a/Perfil/listado_expedidor.php
+++ b/Perfil/listado_expedidor.php
@@ -1,11 +1,7 @@
-<?php
-session_start();
-include 'conexion.php';
-
-if (!isset($_SESSION['usuario_id'])) {
-    header("Location: login.php");
-    exit();
-}
+$baseDir = dirname(__DIR__);
+require_once $baseDir.'/auth.php';
+require_login();
+include $baseDir.'/conexion.php';
 $usuario_id = (int)$_SESSION['usuario_id'];
 
 // Recoger filtros de la URL

--- a/agregar_asociado.php
+++ b/agregar_asociado.php
@@ -1,11 +1,7 @@
 <?php
-session_start();
+require_once __DIR__.'/auth.php';
+require_login();
 include 'conexion.php'; // Conexión a la base de datos
-
-if (!isset($_SESSION['usuario_id'])) {
-    header('Location: /Perfil/inicio_sesion.php');
-    exit();
-}
 
 // Para ver errores en modo desarrollo (opcional)
 ini_set('display_errors', 1);

--- a/agregar_camionero.php
+++ b/agregar_camionero.php
@@ -1,11 +1,7 @@
 <?php
-session_start();
+require_once __DIR__.'/auth.php';
+require_login();
 include 'conexion.php';
-
-if (!isset($_SESSION['usuario_id'])) {
-    header('Location: /Perfil/inicio_sesion.php');
-    exit();
-}
 
 // Ajusta estos si quieres ver errores en local
 ini_set('display_errors', 1);

--- a/auth.php
+++ b/auth.php
@@ -1,0 +1,38 @@
+<?php
+// auth.php - Funciones de autenticacion reutilizables
+
+// Inicia la sesion si no esta iniciada
+function ensure_session_started() {
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
+}
+
+// Redirige al login
+function redirect_to_login() {
+    header('Location: /Perfil/inicio_sesion.php');
+    exit();
+}
+
+// Verifica que el usuario haya iniciado sesion
+function require_login() {
+    ensure_session_started();
+    if (empty($_SESSION['usuario_id'])) {
+        redirect_to_login();
+    }
+}
+
+// Verifica que el usuario tenga alguno de los roles permitidos
+function require_role($allowedRoles) {
+    ensure_session_started();
+    if (empty($_SESSION['usuario_id'])) {
+        redirect_to_login();
+    }
+    $allowed = is_array($allowedRoles) ? $allowedRoles : [$allowedRoles];
+    if (!in_array($_SESSION['rol'] ?? '', $allowed, true)) {
+        http_response_code(403);
+        echo 'Acceso denegado';
+        exit();
+    }
+}
+

--- a/buscador_general.php
+++ b/buscador_general.php
@@ -5,10 +5,9 @@
  *  Requiere: PHP ≥7.4 y las tablas del esquema InterTrucker.
  */
 
-session_start();
+require_once __DIR__.'/auth.php';
+require_login();
 require_once 'conexion.php';
-
-if (!isset($_SESSION['usuario_id'])) { header('Location: login.php'); exit(); }
 $usuario_id = (int)$_SESSION['usuario_id'];
 
 /*--------------------------------------------------

--- a/cambiar_titularidadyseleccionado.php
+++ b/cambiar_titularidadyseleccionado.php
@@ -1,5 +1,6 @@
 <?php
-session_start();
+require_once __DIR__.'/auth.php';
+require_login();
 include 'conexion.php'; // Conexión a la base de datos
 
 // ======================================================
@@ -14,11 +15,6 @@ ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
-// Verificar si el usuario está autenticado
-if (!isset($_SESSION['usuario_id'])) {
-    header("Location: inicio_sesion.php");
-    exit();
-}
 
 // Verificar que llega por POST (y que hay porte_id)
 if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !isset($_POST['porte_id'])) {

--- a/crear_asignacion.php
+++ b/crear_asignacion.php
@@ -1,14 +1,10 @@
 <?php
-session_start();
+require_once __DIR__.'/auth.php';
+require_login();
 include 'conexion.php'; // Conexión a la base de datos
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
-
-if (!isset($_SESSION['usuario_id'])) {
-    header('Location: login.php');
-    exit();
-}
 
 // Obtener el ID del usuario actual
 $usuario_id = $_SESSION['usuario_id'];

--- a/editar_camionero.php
+++ b/editar_camionero.php
@@ -1,5 +1,6 @@
 <?php
-session_start();
+require_once __DIR__.'/auth.php';
+require_login();
 include 'conexion.php'; // Ajusta la ruta a tu archivo de conexión
 
 // ======================================================
@@ -7,12 +8,6 @@ include 'conexion.php'; // Ajusta la ruta a tu archivo de conexión
 // ======================================================
 if (!isset($_SESSION['csrf_token'])) {
     $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
-}
-
-// Verificar si el usuario ha iniciado sesión
-if (!isset($_SESSION['usuario_id'])) {
-    header('Location: /Perfil/inicio_sesion.php');
-    exit();
 }
 
 $usuario_sesion_id = $_SESSION['usuario_id'];

--- a/facturas.php
+++ b/facturas.php
@@ -1,5 +1,6 @@
 <?php
-session_start();
+require_once __DIR__.'/auth.php';
+require_login();
 include 'conexion.php';
 
 ini_set('display_errors',1);
@@ -7,9 +8,6 @@ ini_set('display_startup_errors',1);
 error_reporting(E_ALL);
 
 /* ---------- comprobación de sesión ---------- */
-if (!isset($_SESSION['usuario_id'], $_SESSION['rol'], $_SESSION['admin_id'])) {
-    header('Location: /Perfil/inicio_sesion.php'); exit();
-}
 $usuario_id = $_SESSION['usuario_id'];
 $rol        = $_SESSION['rol'];
 $admin_id   = $_SESSION['admin_id'];

--- a/guardar_hacer_porte.php
+++ b/guardar_hacer_porte.php
@@ -1,15 +1,11 @@
 <?php
-session_start();
+require_once __DIR__.'/auth.php';
+require_login();
 include 'conexion.php';
 
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
-
-if (!isset($_SESSION['usuario_id'])) {
-    header('Location: login.php');
-    exit();
-}
 
 $usuario_id = $_SESSION['usuario_id'];
 $porte_id   = $_POST['porte_id'] ?? null;

--- a/hacer_oferta.php
+++ b/hacer_oferta.php
@@ -4,8 +4,8 @@ ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
-// Iniciar sesión
-session_start();
+require_once __DIR__.'/auth.php';
+require_login();
 
 // Conexión a la base de datos
 include 'conexion.php';
@@ -16,11 +16,8 @@ if (isset($_SESSION['mensaje'])) {
     unset($_SESSION['mensaje']); // Limpiar el mensaje después de mostrarlo
 }
 
-// Verificar si el usuario está autenticado
-if (!isset($_SESSION['usuario_id'])) {
-    die("Error: Usuario no autenticado. <a href='login.php'>Iniciar sesión</a>");
-}
-$usuario_id = $_SESSION['usuario_id']; // ID del usuario autenticado
+// ID del usuario autenticado
+$usuario_id = $_SESSION['usuario_id'];
 
 // Identificar al administrador principal
 $sql_administrador = "SELECT admin_id FROM usuarios WHERE id = ?";

--- a/header.php
+++ b/header.php
@@ -1,5 +1,6 @@
 <?php
-if (session_status() === PHP_SESSION_NONE) session_start();
+require_once __DIR__.'/auth.php';
+require_login();
 if (!empty($_SESSION['impersonador_id'])) {
     echo '
     <div style="background:#ffc107;color:#000;padding:8px 14px;text-align:center;font-weight:bold;position:sticky;top:0;left:0;right:0;z-index:1000;">

--- a/mis_asociados.php
+++ b/mis_asociados.php
@@ -1,15 +1,7 @@
 <?php
-if (session_status() === PHP_SESSION_NONE) {
-    session_start();
-}
-
+require_once __DIR__.'/auth.php';
+require_login();
 include 'conexion.php'; // Conexión a la base de datos
-
-// Verificar si el usuario está autenticado
-if (!isset($_SESSION['usuario_id'])) {
-    header('Location: /Perfil/inicio_sesion.php');
-    exit();
-}
 
 $usuario_id = $_SESSION['usuario_id']; // Usuario en sesión
 

--- a/my_truckers.php
+++ b/my_truckers.php
@@ -1,16 +1,7 @@
 <?php
-if (session_status() === PHP_SESSION_NONE) {
-    session_start();
-}
-
+require_once __DIR__.'/auth.php';
+require_login();
 include 'conexion.php'; // Conexión a la base de datos
-
-// Verificar si el usuario está autenticado
-if (!isset($_SESSION['usuario_id'])) {
-    header('Location: /Perfil/inicio_sesion.php');
-    exit();
-}
-
 $usuario_id = $_SESSION['usuario_id']; // Usuario en sesión
 
 // Filtrar y obtener la lista de camioneros

--- a/portes_nuevos_propios.php
+++ b/portes_nuevos_propios.php
@@ -1,16 +1,13 @@
 <?php
-session_start();
+require_once __DIR__.'/auth.php';
+require_login();
 include 'conexion.php';
 
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
-// Verificar usuario
-if (!isset($_SESSION['usuario_id'])) {
-    header("Location: inicio_sesion.php");
-    exit();
-}
+// ID del usuario autenticado
 $usuario_id = $_SESSION['usuario_id'];
 
 // Obtener admin_id

--- a/s14_ctrl/header.php
+++ b/s14_ctrl/header.php
@@ -3,11 +3,8 @@
  *  Cabecera común – Panel Super-Admin  •  InterTrucker
  *  Fecha: 2025-05-12
  * ----------------------------------------------------------- */
-session_start();
-if (($_SESSION['rol'] ?? '') !== 'superadmin') {
-    header('Location: login.php');
-    exit();
-}
+require_once dirname(__DIR__).'/auth.php';
+require_role('superadmin');
 ?>
 <!DOCTYPE html>
 <html lang="es">

--- a/ver_detalles_vehiculo.php
+++ b/ver_detalles_vehiculo.php
@@ -1,16 +1,8 @@
 <?php
-if (session_status() === PHP_SESSION_NONE) {
-    session_start();
-}
-
+require_once __DIR__.'/auth.php';
+require_login();
 include 'conexion.php'; // Ajusta la ruta si tu archivo de conexión está en otro directorio
 include 'funciones_subida.php';
-
-// Verificar si el usuario está autenticado (opcional, depende de tu app)
-if (!isset($_SESSION['usuario_id'])) {
-    header('Location: login.php');
-    exit();
-}
 
 // Verificar si llega vehiculo_id por GET
 if (!isset($_GET['vehiculo_id'])) {


### PR DESCRIPTION
## Summary
- create `auth.php` with reusable `require_login()` and `require_role()` helpers
- use the new helpers in header and superadmin header
- enforce authentication in various scripts

## Testing
- `php -l auth.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6878a6c463208329a7876921b4ce98e6