### PR TITLE
Add auth checks to event handlers

### DIFF
--- a/datos_multimedia_recogida_entrega.php
+++ b/datos_multimedia_recogida_entrega.php
@@ -1,53 +1,42 @@
 <?php
-include('conexion.php'); // Incluir la conexión a la base de datos
+require_once __DIR__.'/auth.php';
+require_login();
+require_role(['administrador','gestor','camionero','asociado']);
+include('conexion.php');
+header('Content-Type: application/json');
 
-// Verificar que se han recibido los datos necesarios
 if (isset($_POST['evento_id'], $_POST['tipo_archivo'], $_POST['url_archivo'], $_POST['tamano'])) {
-    $evento_id = $_POST['evento_id']; 
-    $tipo_archivo = $_POST['tipo_archivo'];
-    $url_archivo = $_POST['url_archivo'];
-    $tamano = $_POST['tamano'];
-    $geolocalizacion = isset($_POST['geolocalizacion']) ? $_POST['geolocalizacion'] : NULL;
+    $evento_id     = (int)$_POST['evento_id'];
+    $tipo_archivo  = $_POST['tipo_archivo'];
+    $url_archivo   = $_POST['url_archivo'];
+    $tamano        = $_POST['tamano'];
+    $geolocalizacion = $_POST['geolocalizacion'] ?? null;
 
-    // Consulta para insertar los valores en la tabla multimedia_recogida_entrega
-    $sql_insertar = "INSERT INTO multimedia_recogida_entrega (evento_id, tipo_archivo, url_archivo, geolocalizacion, tamano, timestamp)
-                     VALUES ('$evento_id', '$tipo_archivo', '$url_archivo', '$geolocalizacion', '$tamano', NOW())";
-
-    // Ejecutar la consulta
-    if (mysqli_query($conn, $sql_insertar)) {
-        echo json_encode(array("status" => "success", "message" => "Archivo registrado correctamente en la base de datos."));
-    } else {
-        echo json_encode(array("status" => "error", "message" => "Error al insertar en la base de datos: " . mysqli_error($conn)));
+    $admin_id = $_SESSION['admin_id'] ?? 0;
+    $chk = $conn->prepare("SELECT e.id FROM eventos e JOIN portes p ON e.porte_id=p.id JOIN usuarios u ON p.usuario_creador_id=u.id WHERE e.id=? AND u.admin_id=? LIMIT 1");
+    $chk->bind_param('ii', $evento_id, $admin_id);
+    $chk->execute();
+    if ($chk->get_result()->num_rows === 0) {
+        echo json_encode(['status'=>'error','message'=>'acceso denegado']);
+        exit;
     }
+    $chk->close();
+
+    $stmt = $conn->prepare("INSERT INTO multimedia_recogida_entrega (evento_id, tipo_archivo, url_archivo, geolocalizacion, tamano, timestamp) VALUES (?, ?, ?, ?, ?, NOW())");
+    if (!$stmt) {
+        echo json_encode(['status'=>'error','message'=>'prepare failed']);
+        exit;
+    }
+    $stmt->bind_param('isssi', $evento_id, $tipo_archivo, $url_archivo, $geolocalizacion, $tamano);
+    if ($stmt->execute()) {
+        echo json_encode(['status'=>'success','message'=>'Archivo registrado']);
+    } else {
+        echo json_encode(['status'=>'error','message'=>'Error al insertar']);
+    }
+    $stmt->close();
 } else {
-    echo json_encode(array("status" => "error", "message" => "Datos incompletos."));
+    echo json_encode(['status'=>'error','message'=>'Datos incompletos']);
 }
 
-// Cerrar la conexión
-mysqli_close($conn);
-?>
-<?php
-include('conexion.php'); // Incluir la conexión a la base de datos
-
-// Definir las variables necesarias para la inserción
-$evento_id = $_POST['evento_id']; // Asegúrate de que este valor sea pasado desde el formulario
-$tipo_archivo = $_POST['tipo_archivo']; // Foto o Video
-$url_archivo = $_POST['url_archivo']; // Ruta del archivo en el servidor
-$geolocalizacion = isset($_POST['geolocalizacion']) ? $_POST['geolocalizacion'] : NULL;
-$tamano = $_POST['tamano']; // Tamaño del archivo en bytes
-$timestamp = date("Y-m-d H:i:s"); // Timestamp actual
-
-// Consulta para insertar los valores en la tabla multimedia_recogida_entrega
-$sql_insertar = "INSERT INTO multimedia_recogida_entrega (evento_id, tipo_archivo, url_archivo, geolocalizacion, tamano, timestamp)
-                 VALUES ('$evento_id', '$tipo_archivo', '$url_archivo', '$geolocalizacion', '$tamano', '$timestamp')";
-
-// Ejecutar la consulta
-if (mysqli_query($conn, $sql_insertar)) {
-    echo "Registro insertado exitosamente en la tabla multimedia_recogida_entrega.";
-} else {
-    echo "Error al insertar en la base de datos: " . mysqli_error($conn);
-}
-
-// Cerrar la conexión
 mysqli_close($conn);
 ?>

--- a/guardar_recogida.php
+++ b/guardar_recogida.php
@@ -1,65 +1,65 @@
 <?php
-// Conexión a la base de datos
+require_once __DIR__.'/auth.php';
+require_login();
+require_role(['administrador','gestor','camionero','asociado']);
 include 'db_connection.php';
+header('Content-Type: application/json');
 
-// Obtener el ID del porte
-$porte_id = $_POST['porte_id'];
+$porte_id = (int)$_POST['porte_id'];
 
-// Subida de fotos de recogida
+$admin_id = $_SESSION['admin_id'] ?? 0;
+$chk = $conn->prepare("SELECT p.id FROM portes p JOIN usuarios u ON p.usuario_creador_id=u.id WHERE p.id=? AND u.admin_id=? LIMIT 1");
+$chk->bind_param('ii', $porte_id, $admin_id);
+$chk->execute();
+if ($chk->get_result()->num_rows === 0) {
+    echo json_encode(['success'=>false,'message'=>'acceso denegado']);
+    exit;
+}
+$chk->close();
+
+$messages = [];
+
 if (isset($_FILES['foto_recogida'])) {
     $target_dir = "uploads/";
     $file_name = basename($_FILES['foto_recogida']['name']);
     $target_file = $target_dir . $file_name;
-
-    // Mover el archivo a la carpeta 'uploads'
     if (move_uploaded_file($_FILES['foto_recogida']['tmp_name'], $target_file)) {
-        // Insertar la ruta del archivo en la base de datos
-        $sql = "INSERT INTO archivos_entrega_recogida (porte_id, tipo, archivo_nombre) 
-                VALUES ($porte_id, 'foto', '$file_name')";
+        $sql = "INSERT INTO archivos_entrega_recogida (porte_id, tipo, archivo_nombre) VALUES ($porte_id, 'foto', '$file_name')";
         mysqli_query($conn, $sql);
-        echo "Foto de la recogida subida y registrada correctamente.";
+        $messages[] = 'foto subida';
     } else {
-        echo "Error al subir la foto de la recogida.";
+        $messages[] = 'error al subir foto';
     }
 }
 
-// Subida de videos de recogida
 if (isset($_FILES['video_recogida'])) {
     $target_dir = "uploads/";
     $file_name = basename($_FILES['video_recogida']['name']);
     $target_file = $target_dir . $file_name;
-
-    // Mover el archivo a la carpeta 'uploads'
     if (move_uploaded_file($_FILES['video_recogida']['tmp_name'], $target_file)) {
-        // Insertar la ruta del archivo en la base de datos
-        $sql = "INSERT INTO archivos_entrega_recogida (porte_id, tipo, archivo_nombre) 
-                VALUES ($porte_id, 'video', '$file_name')";
+        $sql = "INSERT INTO archivos_entrega_recogida (porte_id, tipo, archivo_nombre) VALUES ($porte_id, 'video', '$file_name')";
         mysqli_query($conn, $sql);
-        echo "Video de la recogida subido y registrado correctamente.";
+        $messages[] = 'video subido';
     } else {
-        echo "Error al subir el video de la recogida.";
+        $messages[] = 'error al subir video';
     }
 }
 
-// Guardar observaciones de la recogida
 if (isset($_POST['observaciones_recogida'])) {
     $observaciones = $_POST['observaciones_recogida'];
     $sql = "UPDATE portes SET observaciones_recogida = '$observaciones' WHERE id = $porte_id";
     mysqli_query($conn, $sql);
 }
 
-// Registrar hora de llegada o salida
 if (isset($_POST['registrar_hora'])) {
     $hora_actual = date('H:i:s');
-
     if ($_POST['registrar_hora'] == 'llegada') {
         $sql = "UPDATE portes SET hora_llegada_recogida = '$hora_actual' WHERE id = $porte_id";
     } elseif ($_POST['registrar_hora'] == 'salida') {
         $sql = "UPDATE portes SET hora_salida_recogida = '$hora_actual' WHERE id = $porte_id";
     }
-
     mysqli_query($conn, $sql);
 }
 
-echo "Recogida registrada correctamente.";
+echo json_encode(['success'=>true,'messages'=>$messages]);
 ?>


### PR DESCRIPTION
## Summary
- enforce login and roles across event endpoints
- validate that ports belong to current admin
- return JSON responses or redirect on failure

## Testing
- `php -l Recogida1.php`
- `php -l eventos_procesar.php`
- `php -l subir_archivo.php`
- `php -l datos_multimedia_recogida_entrega.php`
- `php -l guardar_firma_evento.php`
- `php -l guardar_recogida.php`


------
https://chatgpt.com/codex/tasks/task_e_6878a918a73c8329abe9f8fafd5a3213