### PR TITLE
Add role and admin checks

### DIFF
--- a/actualizar_vehiculo.php
+++ b/actualizar_vehiculo.php
@@ -1,7 +1,28 @@
 <?php
+require_once __DIR__.'/auth.php';
+require_login();
+require_role(['administrador','gestor']);
 include 'conexion.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $vehiculo_id = intval($_POST['vehiculo_id']);
+
+    // Comprobar que el vehículo pertenece a la empresa del usuario
+    $admin_id = $_SESSION['admin_id'] ?? 0;
+    $chk = $conn->prepare(
+        "SELECT v.id
+           FROM vehiculos v
+           JOIN usuarios u ON v.usuario_id = u.id
+          WHERE v.id = ? AND u.admin_id = ?"
+    );
+    $chk->bind_param('ii', $vehiculo_id, $admin_id);
+    $chk->execute();
+    if ($chk->get_result()->num_rows === 0) {
+        http_response_code(403);
+        exit('Acceso denegado');
+    }
+    $chk->close();
+
     $vehiculo_id            = intval($_POST['vehiculo_id']);
     $matricula              = trim($_POST['matricula'] ?? '');
     $marca                  = trim($_POST['marca'] ?? '');

--- a/asignar_porte.php
+++ b/asignar_porte.php
@@ -1,24 +1,62 @@
 <?php
+require_once __DIR__.'/auth.php';
+require_login();
+require_role(['administrador','gestor']);
 include 'conexion.php'; // Conexión a la base de datos
 
-$oferta_id = intval($_POST['oferta_id']); // Oferta seleccionada
-$porte_id = intval($_POST['porte_id']);    // Porte ID
-$ofertas_aceptadas = $_POST['ofertas_aceptadas']; // IDs de las ofertas en aceptado
+$oferta_id = intval($_POST['oferta_id'] ?? 0); // Oferta seleccionada
+$porte_id = intval($_POST['porte_id'] ?? 0);    // Porte ID
+$ofertas_aceptadas = isset($_POST['ofertas_aceptadas']) ? array_map('intval', $_POST['ofertas_aceptadas']) : [];
 
-// Ejecutar la consulta para actualizar el estado de la oferta seleccionada
-$sql_update = "
-UPDATE ofertas_varios
-SET estado_oferta = CASE 
-    WHEN id = $oferta_id THEN 'seleccionado'
-    WHEN id IN (" . implode(',', $ofertas_aceptadas) . ") AND id != $oferta_id THEN 'no_seleccionado'
-    ELSE estado_oferta
-END
-WHERE porte_id = $porte_id;
-";
+// Comprobar que el porte pertenece a la empresa del usuario
+$admin_id = $_SESSION['admin_id'] ?? 0;
+$chk = $conn->prepare(
+    "SELECT p.id
+       FROM portes p
+       JOIN usuarios u ON p.usuario_creador_id = u.id
+      WHERE p.id = ? AND u.admin_id = ?"
+);
+$chk->bind_param('ii', $porte_id, $admin_id);
+$chk->execute();
+if ($chk->get_result()->num_rows === 0) {
+    http_response_code(403);
+    exit('Acceso denegado');
+}
+$chk->close();
 
-// Ejecutar la consulta
-$conn->query($sql_update);
+// Verificar que la oferta seleccionada pertenece al mismo porte
+$chk = $conn->prepare(
+    "SELECT id FROM ofertas_varios WHERE id = ? AND porte_id = ?"
+);
+$chk->bind_param('ii', $oferta_id, $porte_id);
+$chk->execute();
+if ($chk->get_result()->num_rows === 0) {
+    http_response_code(400);
+    exit('Oferta o porte no válidos');
+}
+$chk->close();
 
-// Cerrar la conexión
+// Marcar la oferta seleccionada
+$stmt = $conn->prepare(
+    "UPDATE ofertas_varios SET estado_oferta='seleccionado' WHERE id=? AND porte_id=?"
+);
+$stmt->bind_param('ii', $oferta_id, $porte_id);
+$stmt->execute();
+$stmt->close();
+
+// Marcar el resto como no seleccionado
+if (!empty($ofertas_aceptadas)) {
+    $stmt = $conn->prepare(
+        "UPDATE ofertas_varios SET estado_oferta='no_seleccionado' WHERE id=? AND porte_id=?"
+    );
+    foreach ($ofertas_aceptadas as $oid) {
+        if ($oid != $oferta_id) {
+            $stmt->bind_param('ii', $oid, $porte_id);
+            $stmt->execute();
+        }
+    }
+    $stmt->close();
+}
+
 $conn->close();
 ?>

--- a/cambiar_estado_vehiculo.php
+++ b/cambiar_estado_vehiculo.php
@@ -1,9 +1,28 @@
 <?php
+require_once __DIR__.'/auth.php';
+require_login();
+require_role(['administrador','gestor']);
 include 'conexion.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $vehiculo_id = $_POST['vehiculo_id'];
-    $estado_actual = $_POST['estado_actual'];
+    $vehiculo_id = intval($_POST['vehiculo_id']);
+    $estado_actual = isset($_POST['estado_actual']) ? (int)$_POST['estado_actual'] : 0;
+
+    // Verificar que el vehículo pertenece a la empresa del usuario
+    $admin_id = $_SESSION['admin_id'] ?? 0;
+    $chk = $conn->prepare(
+        "SELECT v.id
+           FROM vehiculos v
+           JOIN usuarios u ON v.usuario_id = u.id
+          WHERE v.id = ? AND u.admin_id = ?"
+    );
+    $chk->bind_param('ii', $vehiculo_id, $admin_id);
+    $chk->execute();
+    if ($chk->get_result()->num_rows === 0) {
+        http_response_code(403);
+        exit('Acceso denegado');
+    }
+    $chk->close();
     $nuevo_estado = $estado_actual == 1 ? 0 : 1;
 
     $sql = "UPDATE vehiculos SET activo = ? WHERE id = ?";

--- a/ver_aceptantes.php
+++ b/ver_aceptantes.php
@@ -1,27 +1,35 @@
 <?php
-// Incluir la conexión a la base de datos
+require_once __DIR__.'/auth.php';
+require_login();
+require_role(['administrador','gestor']);
 include 'db_connection.php';
 
-// Obtener el ID del porte
-$porte_id = $_GET['porte_id'];
+$porte_id = isset($_GET['porte_id']) ? (int)$_GET['porte_id'] : 0;
+$admin_id = $_SESSION['admin_id'] ?? 0;
+$chk = $conn->prepare("SELECT p.id FROM portes p JOIN usuarios u ON p.usuario_creador_id=u.id WHERE p.id=? AND u.admin_id=?");
+$chk->bind_param('ii', $porte_id, $admin_id);
+$chk->execute();
+if ($chk->get_result()->num_rows === 0) {
+    http_response_code(403);
+    exit('Acceso denegado');
+}
+$chk->close();
 
-// Obtener la lista de aceptantes
-$aceptantes = mysqli_query($conn, "SELECT u.id, u.nombre FROM usuarios u 
-    JOIN ofertas o ON u.id = o.destinatario_id 
-    WHERE o.porte_id = $porte_id AND o.estado = 'aceptado'");
+$stmt_acept = $conn->prepare("SELECT u.id, u.nombre FROM usuarios u JOIN ofertas o ON u.id = o.destinatario_id WHERE o.porte_id = ? AND o.estado = 'aceptado'");
+$stmt_acept->bind_param('i', $porte_id);
+$stmt_acept->execute();
+$aceptantes = $stmt_acept->get_result();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    // Asignar el porte al aceptante seleccionado
-    $aceptante_id = $_POST['aceptante_id'];
-    $sql = "UPDATE portes SET asignado_a = $aceptante_id, estado = 'asignado' WHERE id = $porte_id";
-    mysqli_query($conn, $sql);
-
-    // Redirigir a la lista de portes asignados
+    $aceptante_id = (int)$_POST['aceptante_id'];
+    $stmt_up = $conn->prepare("UPDATE portes SET asignado_a=?, estado='asignado' WHERE id=?");
+    $stmt_up->bind_param('ii', $aceptante_id, $porte_id);
+    $stmt_up->execute();
+    $stmt_up->close();
     header('Location: portes_asignados.php');
     exit();
 }
 ?>
-
 <!DOCTYPE html>
 <html lang="es">
 <head>
@@ -30,19 +38,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </head>
 <body>
     <h1>Seleccionar Aceptante para el Porte</h1>
-    
     <form action="ver_aceptantes.php?porte_id=<?php echo $porte_id; ?>" method="POST">
         <fieldset>
             <legend>Usuarios que Han Aceptado la Oferta</legend>
-
-            <?php
-            // Listar los usuarios aceptantes
-            while ($row = mysqli_fetch_assoc($aceptantes)) {
-                echo "<input type='radio' name='aceptante_id' value='{$row['id']}'> {$row['nombre']}<br>";
-            }
-            ?>
+            <?php while ($row = mysqli_fetch_assoc($aceptantes)) { ?>
+                <input type='radio' name='aceptante_id' value='<?php echo $row['id']; ?>'> <?php echo $row['nombre']; ?><br>
+            <?php } ?>
         </fieldset>
-
         <button type="submit">Asignar Porte</button>
     </form>
 </body>


### PR DESCRIPTION
## Summary
- require authentication/gestor or admin role when updating vehicles, assigning a porte and similar
- check that resources belong to the logged admin before modifying
- sanitize ids through prepared statements

## Testing
- `php -l actualizar_vehiculo.php`
- `php -l cambiar_estado_vehiculo.php`
- `php -l asignar_porte.php`
- `php -l ver_aceptantes.php`
- `php -l actualizar_camionero.php`

------
https://chatgpt.com/codex/tasks/task_e_6878ad1b046c8329aeb5c12818b0b489