### PR TITLE
Harden API auth and CORS

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,5 +1,6 @@
 <IfModule mod_headers.c>
-    Header set Access-Control-Allow-Origin "*"
+    # Restrict cross-origin requests to the main site
+    Header set Access-Control-Allow-Origin "https://www.intertrucker.net"
     Header set Access-Control-Allow-Methods "GET, POST, OPTIONS"
     Header set Access-Control-Allow-Headers "Content-Type, Authorization"
 </IfModule>

--- a/api/api_auth.php
+++ b/api/api_auth.php
@@ -1,0 +1,45 @@
+<?php
+require_once __DIR__ . '/../auth.php';
+
+function require_api_login() {
+    ensure_session_started();
+    if (!empty($_SESSION['usuario_id'])) {
+        return;
+    }
+
+    $authHeader = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+    if (preg_match('/Bearer\s+(\S+)/i', $authHeader, $matches)) {
+        $token = $matches[1];
+
+        $conn = new mysqli(
+            getenv('DB_HOST'),
+            getenv('DB_USER'),
+            getenv('DB_PASS'),
+            getenv('DB_NAME')
+        );
+        if (!$conn->connect_error) {
+            $stmt = $conn->prepare('SELECT id, rol, admin_id, nombre_usuario FROM usuarios WHERE token_sesion = ? LIMIT 1');
+            if ($stmt) {
+                $stmt->bind_param('s', $token);
+                $stmt->execute();
+                $result = $stmt->get_result();
+                if ($row = $result->fetch_assoc()) {
+                    $_SESSION['usuario_id'] = (int)$row['id'];
+                    $_SESSION['rol'] = $row['rol'] ?? '';
+                    $_SESSION['admin_id'] = (int)($row['admin_id'] ?? 0);
+                    $_SESSION['nombre_usuario'] = $row['nombre_usuario'] ?? '';
+                    $stmt->close();
+                    $conn->close();
+                    return;
+                }
+                $stmt->close();
+            }
+            $conn->close();
+        }
+    }
+
+    http_response_code(401);
+    header('Content-Type: application/json');
+    echo json_encode(['success' => false, 'message' => 'Unauthorized']);
+    exit();
+}

--- a/api/autologin.php
+++ b/api/autologin.php
@@ -1,4 +1,7 @@
 <?php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 /****************************************************
  * autologin.php
  * ---------------------------------

--- a/api/detalles_portes.php
+++ b/api/detalles_portes.php
@@ -1,10 +1,13 @@
 <?php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
 header("Content-Type: application/json");
-header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 

--- a/api/eventos_estado.php
+++ b/api/eventos_estado.php
@@ -1,4 +1,7 @@
 <?php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 // eventos_estado.php
 
 // Mostrar errores para depuración (desactivar en producción)
@@ -8,7 +11,7 @@ error_reporting(E_ALL);
 
 // Configurar headers para JSON y seguridad
 header("Content-Type: application/json");
-header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: POST");
 header("Access-Control-Allow-Headers: Content-Type, Authorization");
 

--- a/api/eventos_firma.php
+++ b/api/eventos_firma.php
@@ -1,11 +1,14 @@
 <?php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 // eventos_firma.php
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
 header("Content-Type: application/json");
-header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: POST");
 header("Access-Control-Allow-Headers: Content-Type, Authorization");
 

--- a/api/eventos_guardar.php
+++ b/api/eventos_guardar.php
@@ -1,4 +1,7 @@
 <?php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 // eventos_llegada.php
 
 // Mostrar errores para depuración (desactivar en producción)
@@ -8,7 +11,7 @@ error_reporting(E_ALL);
 
 // Configurar headers para JSON y seguridad
 header("Content-Type: application/json");
-header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: POST");
 header("Access-Control-Allow-Headers: Content-Type, Authorization");
 

--- a/api/eventos_llegada.php
+++ b/api/eventos_llegada.php
@@ -1,4 +1,7 @@
 <?php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 // eventos_llegada.php
 
 // Mostrar errores para depuración (desactivar en producción)
@@ -8,7 +11,7 @@ error_reporting(E_ALL);
 
 // Configurar headers para JSON y seguridad
 header("Content-Type: application/json");
-header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: POST");
 header("Access-Control-Allow-Headers: Content-Type, Authorization");
 

--- a/api/eventos_porte.php
+++ b/api/eventos_porte.php
@@ -1,4 +1,7 @@
 <?php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 // Mostrar errores para depuración (desactivar en producción)
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
@@ -6,7 +9,7 @@ error_reporting(E_ALL);
 
 // Configurar headers para JSON y seguridad
 header("Content-Type: application/json");
-header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 

--- a/api/eventos_porte_listar.php
+++ b/api/eventos_porte_listar.php
@@ -1,4 +1,7 @@
 <?php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 /**
  * eventos_porte_listar.php
  * 
@@ -15,7 +18,7 @@ error_reporting(E_ALL);
 
 // Cabeceras para JSON
 header("Content-Type: application/json");
-header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 

--- a/api/eventos_resultado.php
+++ b/api/eventos_resultado.php
@@ -1,4 +1,7 @@
 <?php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 /**
  * eventos_resultado.php  –  Vers. 2025-05-20
  *
@@ -19,7 +22,7 @@ ini_set('display_errors', 1);          // ❌ quítalo en prod.
 error_reporting(E_ALL);
 
 header('Content-Type: application/json');
-header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Origin: https://www.intertrucker.net');
 header('Access-Control-Allow-Methods: POST');
 header('Access-Control-Allow-Headers: Content-Type, Authorization');
 

--- a/api/eventos_salida.php
+++ b/api/eventos_salida.php
@@ -1,4 +1,7 @@
 <?php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 // eventos_salida.php
 
 ini_set('display_errors', 1);
@@ -6,7 +9,7 @@ ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
 header("Content-Type: application/json");
-header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: POST");
 header("Access-Control-Allow-Headers: Content-Type, Authorization");
 

--- a/api/facturas_usuario.php
+++ b/api/facturas_usuario.php
@@ -1,7 +1,10 @@
 <?php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 // Asegurar que se devuelve solo JSON
 header("Content-Type: application/json; charset=UTF-8");
-header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 

--- a/api/guardar_estado_mercancia.php
+++ b/api/guardar_estado_mercancia.php
@@ -1,4 +1,7 @@
 <?php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 // Mostrar errores para depuración (desactivar en producción)
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
@@ -6,7 +9,7 @@ error_reporting(E_ALL);
 
 // Configurar headers para JSON y seguridad
 header("Content-Type: application/json");
-header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: POST");
 header("Access-Control-Allow-Headers: Content-Type, Authorization");
 

--- a/api/multimedia_guardar.php
+++ b/api/multimedia_guardar.php
@@ -1,4 +1,7 @@
 <?php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 /**
  * -------------------------------------------------------------
  * multimedia_guardar.php   –   v2 (mayo 2025)

--- a/api/multimedia_portes.php
+++ b/api/multimedia_portes.php
@@ -1,4 +1,7 @@
 <?php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 // Mostrar errores para depuración (desactivar en producción)
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
@@ -6,7 +9,7 @@ error_reporting(E_ALL);
 
 // Configurar headers para JSON y seguridad
 header("Content-Type: application/json");
-header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 

--- a/api/obtener-datos-usuario.php
+++ b/api/obtener-datos-usuario.php
@@ -1,4 +1,7 @@
 <?php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 // Mostrar errores para depuración (desactivar en producción)
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
@@ -6,7 +9,7 @@ error_reporting(E_ALL);
 
 // Configurar headers para JSON y seguridad
 header("Content-Type: application/json");
-header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 

--- a/api/portes_tren.php
+++ b/api/portes_tren.php
@@ -1,4 +1,7 @@
 <?php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 // Mostrar errores para depuración (desactivar en producción)
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
@@ -6,7 +9,7 @@ error_reporting(E_ALL);
 
 // Configurar headers para JSON y seguridad
 header("Content-Type: application/json");
-header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 

--- a/api/prueba_conexion.php
+++ b/api/prueba_conexion.php
@@ -1,4 +1,7 @@
 <?php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 $host = 'localhost'; // Cambia según corresponda
 $dbname = 'nombre_de_la_base_de_datos';
 $username = 'usuario_de_la_base_de_datos';

--- a/api/subir_factura.php
+++ b/api/subir_factura.php
@@ -1,4 +1,7 @@
 //subir_facturas.php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 <?php
 /** ==============================================================
  *  API · InterTrucker
@@ -17,7 +20,7 @@ ini_set('display_errors', 0);
 error_reporting(0);
 
 header('Content-Type: application/json');
-header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Origin: https://www.intertrucker.net');
 header('Access-Control-Allow-Methods: POST');
 header('Access-Control-Allow-Headers: Content-Type, Authorization');
 

--- a/api/tren.php
+++ b/api/tren.php
@@ -1,10 +1,13 @@
 <?php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
 header("Content-Type: application/json");
-header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 

--- a/api/tren_y_portes_camionero.php
+++ b/api/tren_y_portes_camionero.php
@@ -1,4 +1,7 @@
 <?php
+require_once __DIR__ . "/api_auth.php";
+require_api_login();
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 // Habilitar errores para depurar (en producción se apaga)
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
@@ -6,7 +9,7 @@ error_reporting(E_ALL);
 
 // Encabezados HTTP
 header("Content-Type: application/json");
-header("Access-Control-Allow-Origin: *");
+header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 


### PR DESCRIPTION
## Summary
- restrict global CORS policy
- add an API authentication helper
- require login for private API endpoints

## Testing
- `php -l api/api_auth.php`
- `for f in api/*.php; do php -l "$f"; done | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6878b451a0248329b4d34dbd32bbe939