### PR TITLE
Improve auth for assorted endpoints

### DIFF
--- a/agregar_asociado.php
+++ b/agregar_asociado.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__.'/auth.php';
 require_login();
+require_role(["administrador","gestor"]);
 include 'conexion.php'; // Conexión a la base de datos
 
 // Para ver errores en modo desarrollo (opcional)

--- a/agregar_camionero.php
+++ b/agregar_camionero.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__.'/auth.php';
 require_login();
+require_role(["administrador","gestor"]);
 include 'conexion.php';
 
 // Ajusta estos si quieres ver errores en local

--- a/buscador_general.php
+++ b/buscador_general.php
@@ -7,6 +7,7 @@
 
 require_once __DIR__.'/auth.php';
 require_login();
+require_role(["administrador","gestor","camionero","asociado"]);
 require_once 'conexion.php';
 $usuario_id = (int)$_SESSION['usuario_id'];
 

--- a/buscar_monedas.php
+++ b/buscar_monedas.php
@@ -1,4 +1,7 @@
 <?php
+require_once __DIR__.'/auth.php';
+require_login();
+require_role(["administrador","gestor","camionero","asociado"]);
 include 'conexion.php'; 
 
 $termino = $_POST['termino'];

--- a/cambiar_titularidadyseleccionado.php
+++ b/cambiar_titularidadyseleccionado.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__.'/auth.php';
 require_login();
+require_role(["administrador","gestor"]);
 include 'conexion.php'; // Conexión a la base de datos
 
 // ======================================================
@@ -36,6 +37,15 @@ $usuario_id = $_SESSION['usuario_id'];
 $porte_id = (int)$_POST['porte_id'];
 
 try {
+$admin_id = $_SESSION["admin_id"] ?? 0;
+$chk = $conn->prepare("SELECT p.id FROM portes p JOIN usuarios u ON p.usuario_creador_id=u.id WHERE p.id=? AND u.admin_id=? LIMIT 1");
+$chk->bind_param("ii", $porte_id, $admin_id);
+$chk->execute();
+if ($chk->get_result()->num_rows === 0) {
+    http_response_code(403);
+    exit("Acceso denegado");
+}
+$chk->close();
     // Iniciar una transacción
     $conn->begin_transaction();
 

--- a/crear_asignacion.php
+++ b/crear_asignacion.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__.'/auth.php';
 require_login();
+require_role(["administrador","gestor"]);
 include 'conexion.php'; // Conexión a la base de datos
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/crear_entidad.php
+++ b/crear_entidad.php
@@ -1,6 +1,10 @@
 <?php
+require_once __DIR__.'/auth.php';
+require_login();
+require_role(["administrador","gestor"]);
 // Asegúrate de incluir la conexión a la base de datos
 include 'conexion.php';
+$usuario_id = $_SESSION["usuario_id"];
 
 // Verificar si se ha enviado el formulario
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
@@ -14,13 +18,18 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $observaciones = isset($_POST['observaciones']) ? $conn->real_escape_string($_POST['observaciones']) : null;
 
     // Insertar los datos en la tabla 'entidades'
-    $sql = "INSERT INTO entidades (nombre, direccion, telefono, email, cif, tipo, observaciones) 
-            VALUES ('$nombre', '$direccion', '$telefono', '$email', '$cif', '$tipo', '$observaciones')";
-
-    if ($conn->query($sql) === TRUE) {
-        echo "Entidad creada correctamente.";
+    $sql = "INSERT INTO entidades (nombre, direccion, telefono, email, cif, tipo, observaciones, usuario_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+    $stmt = $conn->prepare($sql);
+    if ($stmt) {
+        $stmt->bind_param("sssssssi", $nombre, $direccion, $telefono, $email, $cif, $tipo, $observaciones, $usuario_id);
+        if ($stmt->execute()) {
+            echo "Entidad creada correctamente.";
+        } else {
+            echo "Error al crear la entidad: " . $stmt->error;
+        }
+        $stmt->close();
     } else {
-        echo "Error al crear la entidad: " . $conn->error;
+        echo "Error en la preparación de la consulta: " . $conn->error;
     }
 
     // Cerrar la conexión

--- a/facturas.php
+++ b/facturas.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__.'/auth.php';
 require_login();
+require_role(["administrador","gestor"]);
 include 'conexion.php';
 
 ini_set('display_errors',1);

--- a/guardar_estado_mercancia.php
+++ b/guardar_estado_mercancia.php
@@ -1,4 +1,7 @@
 <?php
+require_once __DIR__.'/auth.php';
+require_login();
+require_role(["administrador","gestor","camionero","asociado"]);
 // Conexión a la base de datos
 include('conexion.php');
 
@@ -14,6 +17,15 @@ if (empty($porte_id) || empty($tipo_evento) || empty($estado_mercancia)) {
     echo "Error: falta información.";
     exit;
 }
+$admin_id = $_SESSION["admin_id"] ?? 0;
+$chk = $conn->prepare("SELECT p.id FROM portes p JOIN usuarios u ON p.usuario_creador_id=u.id WHERE p.id=? AND u.admin_id=? LIMIT 1");
+$chk->bind_param("ii", $porte_id, $admin_id);
+$chk->execute();
+if ($chk->get_result()->num_rows === 0) {
+    http_response_code(403);
+    exit("Acceso denegado");
+}
+$chk->close();
 
 // Preparar la consulta SQL para actualizar
 $sql = "UPDATE eventos SET estado_mercancia = ?, observaciones = ?, fecha_observaciones = ? WHERE porte_id = ? AND tipo_evento = ?";

--- a/hacer_oferta.php
+++ b/hacer_oferta.php
@@ -6,6 +6,7 @@ error_reporting(E_ALL);
 
 require_once __DIR__.'/auth.php';
 require_login();
+require_role(["administrador","gestor","camionero","asociado"]);
 
 // Conexión a la base de datos
 include 'conexion.php';

--- a/info.php
+++ b/info.php
@@ -1,4 +1,6 @@
 <?php
+require_once __DIR__.'/auth.php';
+require_login();
+require_role(['administrador']);
 phpinfo();
 ?>
-

--- a/mis_asociados.php
+++ b/mis_asociados.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__.'/auth.php';
 require_login();
+require_role(["administrador","gestor"]);
 include 'conexion.php'; // Conexión a la base de datos
 
 $usuario_id = $_SESSION['usuario_id']; // Usuario en sesión

--- a/my_truckers.php
+++ b/my_truckers.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__.'/auth.php';
 require_login();
+require_role(["administrador","gestor"]);
 include 'conexion.php'; // Conexión a la base de datos
 $usuario_id = $_SESSION['usuario_id']; // Usuario en sesión
 

--- a/portes_nuevos_propios.php
+++ b/portes_nuevos_propios.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__.'/auth.php';
 require_login();
+require_role(["administrador","gestor","camionero","asociado"]);
 include 'conexion.php';
 
 ini_set('display_errors', 1);

--- a/ver_detalles_vehiculo.php
+++ b/ver_detalles_vehiculo.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__.'/auth.php';
 require_login();
+require_role(["administrador","gestor"]);
 include 'conexion.php'; // Ajusta la ruta si tu archivo de conexión está en otro directorio
 include 'funciones_subida.php';
 
@@ -9,6 +10,15 @@ if (!isset($_GET['vehiculo_id'])) {
     die("Falta el vehiculo_id en la URL (ej: ver_detalles_vehiculo.php?vehiculo_id=XX).");
 }
 $vehiculo_id = intval($_GET['vehiculo_id']);
+$admin_id = $_SESSION["admin_id"] ?? 0;
+$chk = $conn->prepare("SELECT v.id FROM vehiculos v JOIN usuarios u ON v.usuario_id=u.id WHERE v.id=? AND u.admin_id=? LIMIT 1");
+$chk->bind_param("ii", $vehiculo_id, $admin_id);
+$chk->execute();
+if ($chk->get_result()->num_rows === 0) {
+    http_response_code(403);
+    exit("Acceso denegado");
+}
+$chk->close();
 
 // Ruta para documentos manejada por la función de subida
 


### PR DESCRIPTION
## Summary
- enforce role checks on various pages
- require login for public utilities
- validate admin ownership for updates and downloads

## Testing
- `php -l agregar_asociado.php`
- `php -l agregar_camionero.php`
- `php -l buscador_general.php`
- `php -l buscar_monedas.php`
- `php -l cambiar_titularidadyseleccionado.php`
- `php -l crear_asignacion.php`
- `php -l crear_entidad.php`
- `php -l descargar_facturas.php`
- `php -l facturas.php`
- `php -l guardar_estado_mercancia.php`
- `php -l hacer_oferta.php`
- `php -l info.php`
- `php -l mis_asociados.php`
- `php -l my_truckers.php`
- `php -l portes_nuevos_propios.php`
- `php -l ver_detalles_vehiculo.php`


------
https://chatgpt.com/codex/tasks/task_e_6878b6fb4bf08329a092df744c253af7