### PR TITLE
Implement autologin cookie fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ DB_NAME=your-database-name
 ```
 
 An example file is provided as `.env.example`.
+
+## Autologin desde la app
+
+Para permitir que gestores y administradores accedan a la web sin volver a introducir credenciales, la app puede solicitar un token temporal a `/api/autologin.php`:
+
+1. Realiza una petición `POST` con el parámetro `usuario_id` y encabezado `Authorization: Bearer <token_sesion>`.
+2. La respuesta incluye una URL de autologin que contiene el token seguro.
+3. Abre esa URL en el navegador del dispositivo para iniciar sesión en la web.
+
+El token es válido durante un minuto y solo puede usarse una vez. Al visitarlo, `autologin_mecanismo.php` valida el token, crea la sesión PHP y redirige a la página principal. Si el usuario cierra la sesión web, simplemente solicita un nuevo token desde la app y abra la URL resultante.

--- a/api/autologin_mecanismo.php
+++ b/api/autologin_mecanismo.php
@@ -92,6 +92,27 @@ try {
         }
 
         session_start();
+
+        // -- Ensure the session cookie is available for the whole site
+        if (isset($_COOKIE[session_name()])) {
+            if (PHP_VERSION_ID >= 70300) {
+                setcookie(session_name(), session_id(), [
+                    'expires'  => 0,
+                    'path'     => '/',
+                    'domain'   => $_SERVER['HTTP_HOST'],
+                    'secure'   => !empty($_SERVER['HTTPS']),
+                    'httponly' => true,
+                    'samesite' => 'Lax'
+                ]);
+            } else {
+                // Compatibility with PHP < 7.3
+                setcookie(session_name(), session_id(), 0, '/');
+            }
+
+            // Remove potential previous cookie scoped to /api
+            setcookie(session_name(), '', time() - 3600, '/api');
+        }
+
         $_SESSION['usuario_id']    = $usuarioId;
         $_SESSION['admin_id']      = (int)$usrData['admin_id'];
         $_SESSION['nombre_usuario'] = $usrData['nombre_usuario'] ?? '';


### PR DESCRIPTION
## Summary
- ensure the session cookie created by `autologin_mecanismo.php` is valid for the whole site
- document how to use the autologin endpoint from the mobile app

## Testing
- `php -l api/autologin_mecanismo.php`
- `php -l api/autologin.php`

------
https://chatgpt.com/codex/tasks/task_e_6879f79056a88329be2e831ace83cc7e