### PR TITLE
Centraliza conexión DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-conexion.php
+# conexion.php

--- a/api/api_auth.php
+++ b/api/api_auth.php
@@ -11,12 +11,7 @@ function require_api_login() {
     if (preg_match('/Bearer\s+(\S+)/i', $authHeader, $matches)) {
         $token = $matches[1];
 
-        $conn = new mysqli(
-            getenv('DB_HOST'),
-            getenv('DB_USER'),
-            getenv('DB_PASS'),
-            getenv('DB_NAME')
-        );
+        include_once __DIR__ . '/../conexion.php';
         if (!$conn->connect_error) {
             $stmt = $conn->prepare('SELECT id, rol, admin_id, nombre_usuario FROM usuarios WHERE token_sesion = ? LIMIT 1');
             if ($stmt) {

--- a/api/autologin.php
+++ b/api/autologin.php
@@ -23,23 +23,12 @@ if ($usuarioId < 1) {
     exit;
 }
 
-// --- 2) Conectar a la base de datos usando variables de entorno ---
-$dbHost = getenv('DB_HOST');
-$dbUser = getenv('DB_USER');
-$dbPass = getenv('DB_PASS');
-$dbName = getenv('DB_NAME');
-
-try {
-    $pdo = new PDO(
-        "mysql:host=$dbHost;dbname=$dbName;charset=utf8",
-        $dbUser,
-        $dbPass,
-        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
-    );
-} catch (Exception $e) {
+// --- 2) Conectar a la base de datos ---
+include_once __DIR__ . '/../conexion.php';
+if (!$pdo) {
     echo json_encode([
         "success" => false,
-        "message" => "Error de conexión a la BD: " . $e->getMessage()
+        "message" => "Error de conexión a la BD"
     ]);
     exit;
 }

--- a/api/autologin_mecanismo.php
+++ b/api/autologin_mecanismo.php
@@ -17,21 +17,10 @@ if (empty($token)) {
     exit;
 }
 
-// 2) Conectar a la base de datos usando variables de entorno
-$dbHost = getenv('DB_HOST');
-$dbUser = getenv('DB_USER');
-$dbPass = getenv('DB_PASS');
-$dbName = getenv('DB_NAME');
-
-try {
-    $pdo = new PDO(
-        "mysql:host=$dbHost;dbname=$dbName;charset=utf8",
-        $dbUser,
-        $dbPass,
-        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
-    );
-} catch (Exception $e) {
-    echo "Error de conexión a la BD: " . $e->getMessage();
+// 2) Conectar a la base de datos
+include_once __DIR__ . '/../conexion.php';
+if (!$pdo) {
+    echo "Error de conexión a la BD";
     exit;
 }
 

--- a/api/detalles_portes.php
+++ b/api/detalles_portes.php
@@ -11,12 +11,7 @@ header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 
-$servername = getenv('DB_HOST');
-$username   = getenv('DB_USER');
-$password   = getenv('DB_PASS');
-$dbname     = getenv('DB_NAME');
-
-$conn = new mysqli($servername, $username, $password, $dbname);
+include_once __DIR__ . '/../conexion.php';
 
 $sessionUser  = $_SESSION['usuario_id'] ?? 0;
 $sessionAdmin = $_SESSION['admin_id']  ?? 0;

--- a/api/eventos_firma.php
+++ b/api/eventos_firma.php
@@ -12,14 +12,8 @@ header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: POST");
 header("Access-Control-Allow-Headers: Content-Type, Authorization");
 
-// DATOS DE CONEXIÓN obtenidos de variables de entorno
-$servername = getenv('DB_HOST');
-$username   = getenv('DB_USER');
-$password   = getenv('DB_PASS');
-$dbname     = getenv('DB_NAME');
-
 // Conexión a la base de datos
-$conn = new mysqli($servername, $username, $password, $dbname);
+include_once __DIR__ . '/../conexion.php';
 if ($conn->connect_error) {
     echo json_encode(["success" => false, "message" => "Error de conexión: " . $conn->connect_error]);
     exit;

--- a/api/eventos_porte.php
+++ b/api/eventos_porte.php
@@ -13,14 +13,8 @@ header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 
-// Credenciales de la base de datos obtenidas de variables de entorno
-$servername = getenv('DB_HOST');
-$username   = getenv('DB_USER');
-$password   = getenv('DB_PASS');
-$dbname     = getenv('DB_NAME');
-
 // Conectar a la base de datos
-$conn = new mysqli($servername, $username, $password, $dbname);
+include_once __DIR__ . '/../conexion.php';
 
 $sessionUser  = $_SESSION['usuario_id'] ?? 0;
 $sessionAdmin = $_SESSION['admin_id']  ?? 0;

--- a/api/eventos_salida.php
+++ b/api/eventos_salida.php
@@ -13,12 +13,7 @@ header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: POST");
 header("Access-Control-Allow-Headers: Content-Type, Authorization");
 
-$servername = getenv('DB_HOST');
-$username   = getenv('DB_USER');
-$password   = getenv('DB_PASS');
-$dbname     = getenv('DB_NAME');
-
-$conn = new mysqli($servername, $username, $password, $dbname);
+include_once __DIR__ . '/../conexion.php';
 if ($conn->connect_error) {
     echo json_encode(["success" => false, "message" => "Error de conexión: " . $conn->connect_error]);
     exit;

--- a/api/facturas_usuario.php
+++ b/api/facturas_usuario.php
@@ -13,13 +13,8 @@ ini_set('display_errors', 0);
 ini_set('display_startup_errors', 0);
 error_reporting(0);
 
-// Conexión a la base de datos usando variables de entorno
-$servername = getenv('DB_HOST');
-$username   = getenv('DB_USER');
-$password   = getenv('DB_PASS');
-$dbname     = getenv('DB_NAME');
-
-$conn = new mysqli($servername, $username, $password, $dbname);
+// Conexión a la base de datos
+include_once __DIR__ . '/../conexion.php';
 
 $sessionUser  = $_SESSION['usuario_id'] ?? 0;
 $sessionAdmin = $_SESSION['admin_id']  ?? 0;

--- a/api/guardar_estado_mercancia.php
+++ b/api/guardar_estado_mercancia.php
@@ -13,14 +13,8 @@ header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: POST");
 header("Access-Control-Allow-Headers: Content-Type, Authorization");
 
-// Credenciales de la base de datos obtenidas de variables de entorno
-$servername = getenv('DB_HOST');
-$username   = getenv('DB_USER');
-$password   = getenv('DB_PASS');
-$dbname     = getenv('DB_NAME');
-
 // Conectar a la base de datos
-$conn = new mysqli($servername, $username, $password, $dbname);
+include_once __DIR__ . '/../conexion.php';
 if ($conn->connect_error) {
     echo json_encode(["success" => false, "message" => "Error de conexión: " . $conn->connect_error]);
     exit;

--- a/api/multimedia_portes.php
+++ b/api/multimedia_portes.php
@@ -13,14 +13,8 @@ header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 
-// Credenciales de la base de datos obtenidas de variables de entorno
-$servername = getenv('DB_HOST');
-$username   = getenv('DB_USER');
-$password   = getenv('DB_PASS');
-$dbname     = getenv('DB_NAME');
-
 // Conectar a la base de datos
-$conn = new mysqli($servername, $username, $password, $dbname);
+include_once __DIR__ . '/../conexion.php';
 
 $sessionUser  = $_SESSION['usuario_id'] ?? 0;
 $sessionAdmin = $_SESSION['admin_id']  ?? 0;

--- a/api/obtener-datos-usuario.php
+++ b/api/obtener-datos-usuario.php
@@ -13,14 +13,8 @@ header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 
-// Credenciales de la base de datos obtenidas de variables de entorno
-$servername = getenv('DB_HOST');
-$username   = getenv('DB_USER');
-$password   = getenv('DB_PASS');
-$dbname     = getenv('DB_NAME');
-
 // Conectar a la base de datos
-$conn = new mysqli($servername, $username, $password, $dbname);
+include_once __DIR__ . '/../conexion.php';
 
 $sessionUser  = $_SESSION['usuario_id'] ?? 0;
 $sessionAdmin = $_SESSION['admin_id']  ?? 0;

--- a/api/portes_tren.php
+++ b/api/portes_tren.php
@@ -13,14 +13,8 @@ header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 
-// Credenciales de la base de datos obtenidas de variables de entorno
-$servername = getenv('DB_HOST');
-$username   = getenv('DB_USER');
-$password   = getenv('DB_PASS');
-$dbname     = getenv('DB_NAME');
-
 // Conectar a la base de datos
-$conn = new mysqli($servername, $username, $password, $dbname);
+include_once __DIR__ . '/../conexion.php';
 
 $sessionUser  = $_SESSION['usuario_id'] ?? 0;
 $sessionAdmin = $_SESSION['admin_id']  ?? 0;

--- a/api/prueba_conexion.php
+++ b/api/prueba_conexion.php
@@ -2,15 +2,10 @@
 require_once __DIR__ . "/api_auth.php";
 require_api_login();
 header("Access-Control-Allow-Origin: https://www.intertrucker.net");
-$host = 'localhost'; // Cambia según corresponda
-$dbname = 'nombre_de_la_base_de_datos';
-$username = 'usuario_de_la_base_de_datos';
-$password = 'contraseña_de_la_base_de_datos';
-
-try {
-    $pdo = new PDO("mysql:host=$host;dbname=$dbname;charset=utf8", $username, $password);
+include_once __DIR__ . '/../conexion.php';
+if ($pdo) {
     echo "Conexión exitosa a la base de datos.";
-} catch (PDOException $e) {
-    echo "Error de conexión: " . $e->getMessage();
+} else {
+    echo "Error de conexión";
 }
 ?>

--- a/api/subir_factura.php
+++ b/api/subir_factura.php
@@ -27,12 +27,8 @@ header('Access-Control-Allow-Headers: Content-Type, Authorization');
 /* --------------------------------------------------------------
  * 0) Conexión a la base de datos
  * ------------------------------------------------------------*/
-$servername = getenv('DB_HOST');
-$username   = getenv('DB_USER');
-$password   = getenv('DB_PASS');
-$dbname     = getenv('DB_NAME');
-
-$conn = new mysqli($servername, $username, $password, $dbname);
+include_once __DIR__ . '/../conexion.php';
+// $conn se define en conexion.php
 if ($conn->connect_error) {
     echo json_encode([
         'success' => false,

--- a/api/tren.php
+++ b/api/tren.php
@@ -11,12 +11,7 @@ header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 
-$servername = getenv('DB_HOST');
-$username   = getenv('DB_USER');
-$password   = getenv('DB_PASS');
-$dbname     = getenv('DB_NAME');
-
-$conn = new mysqli($servername, $username, $password, $dbname);
+include_once __DIR__ . '/../conexion.php';
 
 $sessionUser  = $_SESSION['usuario_id'] ?? 0;
 $sessionAdmin = $_SESSION['admin_id']  ?? 0;

--- a/api/tren_y_portes_camionero.php
+++ b/api/tren_y_portes_camionero.php
@@ -13,14 +13,8 @@ header("Access-Control-Allow-Origin: https://www.intertrucker.net");
 header("Access-Control-Allow-Methods: GET");
 header("Access-Control-Allow-Headers: Content-Type");
 
-// Credenciales de la base de datos obtenidas de variables de entorno
-$servername = getenv('DB_HOST');
-$username   = getenv('DB_USER');
-$password   = getenv('DB_PASS');
-$dbname     = getenv('DB_NAME');
-
 // Conectar al servidor
-$conn = new mysqli($servername, $username, $password, $dbname);
+include_once __DIR__ . '/../conexion.php';
 
 $sessionUser  = $_SESSION['usuario_id'] ?? 0;
 $sessionAdmin = $_SESSION['admin_id']  ?? 0;

--- a/api/verificar-credenciales.php
+++ b/api/verificar-credenciales.php
@@ -33,24 +33,12 @@ if (empty($email) || empty($contrasena)) {
     exit;
 }
 
-// 3) Datos de conexión obtenidos de variables de entorno
-$servername = getenv('DB_HOST');
-$username   = getenv('DB_USER');
-$password   = getenv('DB_PASS');
-$dbname     = getenv('DB_NAME');
-
-// 4) Conexión PDO
-try {
-    $pdo = new PDO(
-        "mysql:host=$servername;dbname=$dbname;charset=utf8mb4",
-        $username,
-        $password
-    );
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-} catch (Exception $e) {
+// 3) Conexión PDO
+include_once __DIR__ . '/../conexion.php';
+if (!$pdo) {
     echo json_encode([
         "success" => false,
-        "message" => "Error de conexión a la base de datos: " . $e->getMessage()
+        "message" => "Error de conexión a la base de datos"
     ]);
     exit;
 }

--- a/conexion.php
+++ b/conexion.php
@@ -1,0 +1,18 @@
+<?php
+$servername = 'localhost';
+$username = 'root';
+$password = 'secret';
+$dbname = 'mydatabase';
+
+$conn = new mysqli($servername, $username, $password, $dbname);
+if ($conn->connect_error) {
+    die('Error de conexión: ' . $conn->connect_error);
+}
+
+try {
+    $pdo = new PDO("mysql:host=$servername;dbname=$dbname;charset=utf8mb4", $username, $password);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+} catch (Exception $e) {
+    die('Error de conexión PDO: ' . $e->getMessage());
+}
+?>


### PR DESCRIPTION
## Summary
- create `conexion.php` with database credentials
- load it in all API scripts via `include_once`
- stop using environment variables for DB credentials
- ignore rule for `conexion.php` in `.gitignore`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a7dabef148329ab70d75ef9503080