### PR TITLE
Ensure IDs returned as numbers in APIs

### DIFF
--- a/api/detalles_portes.php
+++ b/api/detalles_portes.php
@@ -89,6 +89,17 @@ try {
     $stmt->execute();
     $result = $stmt->get_result();
     $portes = $result->fetch_all(MYSQLI_ASSOC);
+    foreach ($portes as &$p) {
+        $intFields = [
+            'id','usuario_creador_id','destinatario_usuario_id','destinatario_entidad_id',
+            'expedidor_usuario_id','expedidor_entidad_id','cliente_usuario_id','cliente_entidad_id'
+        ];
+        foreach ($intFields as $f) {
+            if (isset($p[$f])) {
+                $p[$f] = (int)$p[$f];
+            }
+        }
+    }
 
     if (empty($portes)) {
         echo json_encode([

--- a/api/eventos_porte.php
+++ b/api/eventos_porte.php
@@ -72,6 +72,14 @@ try {
     $stmtEventos->execute();
     $resultEventos = $stmtEventos->get_result();
     $eventos = $resultEventos->fetch_all(MYSQLI_ASSOC);
+    foreach ($eventos as &$e) {
+        if (isset($e['id'])) {
+            $e['id'] = (int)$e['id'];
+        }
+        if (isset($e['porte_id'])) {
+            $e['porte_id'] = (int)$e['porte_id'];
+        }
+    }
 
     if (empty($eventos)) {
         echo json_encode([

--- a/api/eventos_porte_listar.php
+++ b/api/eventos_porte_listar.php
@@ -97,6 +97,9 @@ $result = $stmt->get_result();
 // Recopilar los registros
 $rows = [];
 while ($row = $result->fetch_assoc()) {
+    if (isset($row['porte_id'])) {
+        $row['porte_id'] = (int)$row['porte_id'];
+    }
     $rows[] = $row;
 }
 $stmt->close();

--- a/api/eventos_resultado.php
+++ b/api/eventos_resultado.php
@@ -108,6 +108,9 @@ $res = $conn->query("
 ");
 
 $row = $res ? $res->fetch_assoc() : null;
+if ($row) {
+    $row['porte_id'] = (int)$row['porte_id'];
+}
 
 echo json_encode([
     "success" => true,

--- a/api/facturas_usuario.php
+++ b/api/facturas_usuario.php
@@ -67,6 +67,11 @@ $resultFacturas = $stmt->get_result();
 $facturas = [];
 
 while ($row = $resultFacturas->fetch_assoc()) {
+    foreach (['id','usuario_id','tren_id'] as $f) {
+        if (isset($row[$f])) {
+            $row[$f] = (int)$row[$f];
+        }
+    }
     $facturas[] = $row;
 }
 

--- a/api/multimedia_portes.php
+++ b/api/multimedia_portes.php
@@ -67,6 +67,14 @@ try {
     $stmtMultimedia->execute();
     $resultMultimedia = $stmtMultimedia->get_result();
     $archivos = $resultMultimedia->fetch_all(MYSQLI_ASSOC);
+    foreach ($archivos as &$a) {
+        if (isset($a['id'])) {
+            $a['id'] = (int)$a['id'];
+        }
+        if (isset($a['tamano'])) {
+            $a['tamano'] = (float)$a['tamano'];
+        }
+    }
 
     if (empty($archivos)) {
         echo json_encode([

--- a/api/obtener-datos-usuario.php
+++ b/api/obtener-datos-usuario.php
@@ -54,6 +54,10 @@ try {
     $stmtUsuario->execute();
     $resultUsuario = $stmtUsuario->get_result();
     $usuario = $resultUsuario->fetch_assoc();
+    if ($usuario) {
+        $usuario['usuario_id'] = (int)$usuario['usuario_id'];
+        $usuario['estado'] = isset($usuario['estado']) ? (int)$usuario['estado'] : 0;
+    }
 
     if (!$usuario) {
         echo json_encode([
@@ -78,6 +82,11 @@ try {
     $stmtCamionero->execute();
     $resultCamionero = $stmtCamionero->get_result();
     $camionero = $resultCamionero->fetch_assoc();
+    if ($camionero) {
+        $camionero['id'] = (int)$camionero['id'];
+        $camionero['usuario_id'] = (int)$camionero['usuario_id'];
+        $camionero['activo'] = isset($camionero['activo']) ? (int)$camionero['activo'] : 0;
+    }
 
     // Respuesta con los datos del usuario y camionero (si aplica)
     echo json_encode([

--- a/api/portes_tren.php
+++ b/api/portes_tren.php
@@ -57,6 +57,13 @@ try {
     $stmtPortesTren->execute();
     $resultPortesTren = $stmtPortesTren->get_result();
     $portes = $resultPortesTren->fetch_all(MYSQLI_ASSOC);
+    foreach ($portes as &$p) {
+        foreach (['id','porte_id','usuario_id'] as $f) {
+            if (isset($p[$f])) {
+                $p[$f] = (int)$p[$f];
+            }
+        }
+    }
 
     if (empty($portes)) {
         echo json_encode([

--- a/api/tren.php
+++ b/api/tren.php
@@ -46,6 +46,11 @@ try {
     $stmtTrenes->execute();
     $resultTrenes = $stmtTrenes->get_result();
     $trenes = $resultTrenes->fetch_all(MYSQLI_ASSOC);
+    foreach ($trenes as &$t) {
+        if (isset($t['id'])) {
+            $t['id'] = (int)$t['id'];
+        }
+    }
 
     echo json_encode(["success" => true, "data" => $trenes]);
 } catch (Exception $e) {

--- a/api/tren_y_portes_camionero.php
+++ b/api/tren_y_portes_camionero.php
@@ -88,6 +88,9 @@ try {
     $stmtTren->execute();
     $resultTren = $stmtTren->get_result();
     $rowTren = $resultTren->fetch_assoc();
+    if ($rowTren) {
+        $rowTren['tren_id'] = (int)$rowTren['tren_id'];
+    }
 
     if (!$rowTren) {
         // Camionero no tiene tren
@@ -143,6 +146,17 @@ try {
     $stmtPortes->execute();
     $resultPortes = $stmtPortes->get_result();
     $portes = $resultPortes->fetch_all(MYSQLI_ASSOC);
+    foreach ($portes as &$p) {
+        $intFields = [
+            'id','usuario_creador_id','destinatario_usuario_id','destinatario_entidad_id',
+            'expedidor_usuario_id','expedidor_entidad_id','cliente_usuario_id','cliente_entidad_id'
+        ];
+        foreach ($intFields as $f) {
+            if (isset($p[$f])) {
+                $p[$f] = (int)$p[$f];
+            }
+        }
+    }
 
     // Respuesta final
     echo json_encode([

--- a/eventos_porte.php
+++ b/eventos_porte.php
@@ -69,6 +69,14 @@ try {
     $stmtEventos->execute();
     $resultEventos = $stmtEventos->get_result();
     $eventos = $resultEventos->fetch_all(MYSQLI_ASSOC);
+    foreach ($eventos as &$e) {
+        if (isset($e['id'])) {
+            $e['id'] = (int)$e['id'];
+        }
+        if (isset($e['porte_id'])) {
+            $e['porte_id'] = (int)$e['porte_id'];
+        }
+    }
 
     if (empty($eventos)) {
         echo json_encode([

--- a/eventos_porte_listar.php
+++ b/eventos_porte_listar.php
@@ -84,6 +84,9 @@ if (!$result) {
 // Recopilar los registros
 $rows = [];
 while ($row = $result->fetch_assoc()) {
+    if (isset($row['porte_id'])) {
+        $row['porte_id'] = (int)$row['porte_id'];
+    }
     $rows[] = $row;
 }
 


### PR DESCRIPTION
## Summary
- cast numeric fields to `int` in multiple API responses so JSON doesn't send IDs as strings
- update user data, train queries, port queries, multimedia and event listings

## Testing
- `php -l api/obtener-datos-usuario.php`
- `php -l api/tren.php`
- `php -l api/portes_tren.php`
- `php -l api/tren_y_portes_camionero.php`
- `php -l api/detalles_portes.php`
- `php -l api/multimedia_portes.php`
- `php -l api/eventos_porte.php`
- `php -l api/eventos_resultado.php`
- `php -l api/eventos_porte_listar.php`
- `php -l api/facturas_usuario.php`
- `php -l eventos_porte.php`
- `php -l eventos_porte_listar.php`


------
https://chatgpt.com/codex/tasks/task_e_687a9a0ff5308329806a6caa014cf79d