### PR TITLE
Fix numeric types in login response

### DIFF
--- a/api/verificar-credenciales.php
+++ b/api/verificar-credenciales.php
@@ -139,15 +139,27 @@ try {
         ':uid' => $usuarioId
     ]);
 
+    // Mapear rol a un identificador numérico para la app
+    $rolMap = [
+        'administrador' => 1,
+        'gestor'        => 2,
+        'camionero'     => 3,
+        'asociado'      => 4,
+        'superadmin'    => 5
+    ];
+    $rolNombre = $row['rol'] ?? '';
+    $rolId = $rolMap[$rolNombre] ?? 0;
+
     // Respuesta final
     echo json_encode([
         "success" => true,
         "message" => "Credenciales válidas",
         "data" => [
-            "usuario_id"   => $usuarioId,
-            "rol"          => $row['rol'] ?? '',
-            "camionero_id" => $camioneroId,
-            "tren_id"      => $trenId,
+            "usuario_id"   => (int)$usuarioId,
+            "rol"          => $rolNombre,
+            "rol_id"       => $rolId,
+            "camionero_id" => (int)$camioneroId,
+            "tren_id"      => (int)$trenId,
             "tren_nombre"  => $trenNombre,
             "email"        => $row['email'] ?? '',
             "nombre"       => $row['nombre_usuario'] ?? '',


### PR DESCRIPTION
## Summary
- add numeric `rol_id` field in `verificar-credenciales.php`
- keep all id fields as integers for the mobile app

## Testing
- `php -l api/verificar-credenciales.php`

------
https://chatgpt.com/codex/tasks/task_e_687b83c701a883299bd849bcf1a18fa9