### PR TITLE
Add autologin cleanup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,20 @@ El token es válido durante un minuto y solo puede usarse una vez. Al visitarlo,
 
 > **Note**
 > El script `login_directo.php` se ha eliminado. Utiliza siempre la URL devuelta por `/api/autologin.php`, que redirige a `api/autologin_mecanismo.php` para completar el inicio de sesión.
+
+## Limpieza de tokens de autologin
+
+El script `cleanup_autologin.php` elimina de la tabla `autologin_tokens` los registros caducados (campo `fecha_expira` en el pasado) o que ya han sido usados (`usado=1`).
+
+Ejecuta manualmente con:
+
+```
+php cleanup_autologin.php
+```
+
+Puedes programar su ejecución periódica mediante `cron`. Por ejemplo, para ejecutarlo una vez cada hora añade una línea similar a esta:
+
+```
+0 * * * * /usr/bin/php /ruta/a/web-intertrucker/cleanup_autologin.php >/dev/null 2>&1
+```
+

--- a/cleanup_autologin.php
+++ b/cleanup_autologin.php
@@ -1,0 +1,13 @@
+<?php
+require_once __DIR__ . '/conexion.php';
+
+$now = date('Y-m-d H:i:s');
+
+try {
+    $stmt = $pdo->prepare("DELETE FROM autologin_tokens WHERE fecha_expira < ? OR usado = 1");
+    $stmt->execute([$now]);
+    $deleted = $stmt->rowCount();
+    echo "Deleted $deleted expired or used tokens\n";
+} catch (Exception $e) {
+    echo "Error cleaning tokens: " . $e->getMessage() . "\n";
+}


### PR DESCRIPTION
## Summary
- implement `cleanup_autologin.php` for removing expired or used autologin tokens
- document cron usage in README

## Testing
- `php -l cleanup_autologin.php`


------
https://chatgpt.com/codex/tasks/task_e_687b8f3da0448329b0249e26b2d8d760